### PR TITLE
Removing pipeline Channel=PREVIEW 

### DIFF
--- a/infra/modules/gateway_pipeline/main.tf
+++ b/infra/modules/gateway_pipeline/main.tf
@@ -91,7 +91,6 @@ resource "databricks_pipeline" "gateway" {
       }
     }
   }
-  channel                = "PREVIEW"
   allow_duplicate_names  = false
   development            = false
   continuous             = true

--- a/infra/modules/ingestion_pipeline/main.tf
+++ b/infra/modules/ingestion_pipeline/main.tf
@@ -117,7 +117,6 @@ resource "databricks_pipeline" "ingest" {
   }
   schema  = var.destination_schema
   catalog = var.destination_catalog
-  channel = "PREVIEW"
 
   # Dynamically adjust based on choice made in configuration
   dynamic "event_log" {


### PR DESCRIPTION
This setting is not meant for production, hence ideal to remove it since customers will want to use this project without updating the modules.