### PR TITLE
Add MySQL support, per-table destination overrides, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ It is intended to be a database-agnostic, YAML-driven Terraform deployment for D
 ## Key Features:
 - **Database-agnostic**: Supports various Lakeflow Connect-supported databases by simply changing the `source_type` in the config.
     - Currently tested and verified connectors are:
-        - SQL Server CDC ([Public docs](https://docs.databricks.com/en/connect/unity-catalog/sql-server.html))
-        - PostgreSQL CDC ([Public docs](https://docs.databricks.com/en/connect/unity-catalog/postgresql.html))
+        - SQL Server CDC ([Public docs](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/sql-server-pipeline))
+        - PostgreSQL CDC ([Public docs](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/postgresql-pipeline))
         - Oracle (public docs to be added once in public preview)
+        - MySQL ([Public docs](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/mysql-pipeline))
 - **YAML-driven configuration**: Define connections, databases, schemas, tables, and schedules in a single configuration file
 - **Flexible Unity Catalog mapping**: Configure where data lands with per-database catalog and schema customization
 - **Flexible ingestion modes**: Choose between full schema ingestion or specific table selection per database
@@ -47,6 +48,7 @@ lakeflow-connect-terraform/
 ├── config/                      # YAML configuration files
 │   ├── lakeflow_dev.yml        # Active configuration
 │   └── examples/                # Example configurations
+│       ├── mysql.yml             # MySQL example
 │       ├── oracle.yml            # Oracle example
 │       ├── postgresql.yml        # PostgreSQL example
 │       └── sqlserver.yml         # SQL Server example
@@ -86,6 +88,7 @@ Create a Databricks Unity Catalog connection to your source database and specify
 Refer to Databricks documentation for your database type:
 - [SQL Server Connection Setup](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/sql-server-overview)
 - [PostgreSQL Connection Setup](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/postgresql-source-setup)
+- [MySQL Connection Setup](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/mysql-privileges)
 - **Oracle**: Create a Unity Catalog connection to your Oracle source. (public docs to be added once in public preview)
 
 #### 2. Create Unity Catalog Structure
@@ -110,6 +113,9 @@ Ensure CDC is enabled on the source database and tables. Refer to [SQL Server CD
 
 **For Oracle Sources:**
 In your YAML config, set `connection.source_type: "ORACLE"` and provide `connection.connection_parameters.source_catalog` with your Oracle CDB (container database) name (e.g. `ORCLCDB`). See `config/examples/oracle.yml`. (public docs to be added once in public preview)
+
+**For MySQL Sources:**
+MySQL has no schema level (server → database → tables). In the YAML, list each database and under `schemas` use a placeholder name (e.g. `"<not applicable in MySQL>"`) and list tables by their **full MySQL table name**. Set `connection.source_type: "MYSQL"`. If you set `use_schema_ingestion: true`, it is ignored and ingestion uses the tables list; the Pydantic validator prints an info message when you run it. See `config/examples/mysql.yml`.
 
 #### 4. Grant Permissions
 Provide the user/SPN used for Terraform deployment with:
@@ -145,6 +151,9 @@ cp config/examples/sqlserver.yml config/lakeflow_<your_env>.yml
 
 # For Oracle:
 cp config/examples/oracle.yml config/lakeflow_<your_env>.yml
+
+# For MySQL:
+cp config/examples/mysql.yml config/lakeflow_<your_env>.yml
 
 # Edit the YAML file with your environment details
 ```
@@ -263,7 +272,7 @@ poetry run terraform apply --var yaml_config_path=../config/lakeflow_<env>.yml
 
 ## YAML Configuration
 
-See `config/examples/` for complete example configurations ([Oracle](config/examples/oracle.yml), [PostgreSQL](config/examples/postgresql.yml), [SQL Server](config/examples/sqlserver.yml)). The configuration is fully YAML-driven with the following main sections:
+See `config/examples/` for complete example configurations ([MySQL](config/examples/mysql.yml), [Oracle](config/examples/oracle.yml), [PostgreSQL](config/examples/postgresql.yml), [SQL Server](config/examples/sqlserver.yml)). The configuration is fully YAML-driven with the following main sections:
 
 ### Connection
 ```yaml
@@ -311,12 +320,18 @@ databases:
         tables:
           - source_table: users
           - source_table: orders
+          # Optional per-table overrides (default to schema/database-level catalog and schema):
+          - source_table: orders_archive
+            destination_table: orders_archive_v2  # optional
+            destination_catalog: other_catalog   # optional
+            destination_schema: other_schema    # optional
 ```
 
 - Per-database `uc_catalog`: Override global catalog for specific database (optional)
 - Per-database `schema_prefix` and `schema_suffix`: Customize destination schema names (optional)
 - Per-database `replication_slot` and `publication`: PostgreSQL replication configuration (PostgreSQL only)
 - Schemas and tables to ingest with granular control
+- Per-table destination overrides: For table-level ingestion (`use_schema_ingestion: false`), each table can optionally specify `destination_table`, `destination_catalog`, and `destination_schema`. When set, they override the pipeline default (from database/schema config). Catalogs and schemas used by per-table overrides are validated and must exist in Unity Catalog.
 
 ### Event Logs
 ```yaml

--- a/config/examples/mysql.yml
+++ b/config/examples/mysql.yml
@@ -1,0 +1,95 @@
+# MySQL has server → database → tables (no schema level; database and schema are synonymous).
+# In this config you list each database and under schemas use a placeholder name (e.g. "<not applicable in MySQL>")
+# and list tables by their full MySQL table name. The infra maps:
+#   - source_catalog (API) → "default_catalog"
+#   - source_schema (API)  → database name (the MySQL "database")
+#   - source_table (API)  → exactly the table names you list below (full names)
+
+env: "dev"
+app_name: "wealth_mgmt"
+
+connection:
+  name: "mysql_aurora_amenon_connection_v1"
+  source_type: "MYSQL"
+
+unity_catalog:
+  global_uc_catalog: "amenon"
+  staging_uc_catalog: "amenon"
+  staging_schema: "default"
+
+gateway_pipeline_cluster_policy_name: job_compute_for_spn_for_lf_connect
+
+# For MySQL, each entry under 'databases' is a MySQL database. Use placeholder schema name
+# (e.g. "<not applicable in MySQL>") and list tables by their full name. destination_schema in UC
+# is one per database (db.name); optional schema_prefix/schema_suffix apply to that.
+databases:
+  - name: wealth_mgmt_one
+    # schema_prefix / schema_suffix apply to destination_schema (default: db.name)
+    # schema_prefix: "wm1_"
+    # schema_suffix: "_raw"
+    schemas:
+      - name: _ #"<not applicable in MySQL>"
+        use_schema_ingestion: true
+        tables:
+          - source_table: client_management_accounts
+          - source_table: client_management_advisors
+          - source_table: client_management_clients
+      - name: _ #"<not applicable in MySQL>"
+        use_schema_ingestion: true
+        tables:
+          - source_table: portfolio_management_holdings
+          - source_table: portfolio_management_portfolios
+          - source_table: portfolio_management_transactions
+  - name: wealth_mgmt_two
+    uc_catalog: "amenon"
+    schemas:
+      - name: "<not applicable in MySQL>"
+        use_schema_ingestion: false
+        tables:
+          - source_table: client_management_accounts
+          - source_table: client_management_advisors
+          - source_table: client_management_clients
+      - name: "<not applicable in MySQL>"
+        use_schema_ingestion: false
+        tables:
+          - source_table: portfolio_management_holdings
+          - source_table: portfolio_management_portfolios
+          - source_table: portfolio_management_transactions
+
+gateway_pipeline_cluster_config:
+  label: "default"
+  node_type_id: "r5.xlarge"  # Note: This is an AWS compute example being used.
+  autoscale:
+    min_workers: 0
+    max_workers: 0
+    mode: ENHANCED
+  apply_policy_default_values: false
+  enable_local_disk_encryption: false
+  custom_tags: {}
+  spark_conf: {}
+  spark_env_vars: {}
+  ssh_public_keys: []
+
+gateway_validation:
+  timeout_minutes: 30
+  check_interval_seconds: 15
+
+event_log:
+  to_table: true
+
+job:
+  common_job_for_all_pipelines: false
+  common_schedule:
+    quartz_cron_expression: "0 */30 * * * ?"
+    timezone_id: "UTC"
+  per_database_schedules:
+    - name: "frequent_sync"
+      applies_to: ["wealth_mgmt_one"]
+      schedule:
+        quartz_cron_expression: "0 */15 * * * ?"
+        timezone_id: "UTC"
+    - name: "hourly_sync"
+      applies_to: ["wealth_mgmt_two"]
+      schedule:
+        quartz_cron_expression: "0 0 * * * ?"
+        timezone_id: "UTC"

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -8,6 +8,9 @@ locals {
   connection = local.cfg.connection
   job        = local.cfg.job
 
+  # MySQL has no schema level (database = schema). Used to set source_catalog/source_schema and table naming.
+  is_mysql = try(local.connection.source_type, "") == "MYSQL"
+
   # Event log configuration - defaults to true if not specified
   event_log_to_table = try(local.cfg.event_log.to_table, true)
 
@@ -35,20 +38,33 @@ locals {
     pair.destination_schema
   ])
 
-  # Get list of unique catalogs grouped by catalog name for validation
-  landing_catalogs_map = {
+  # All (catalog, schema) landing targets including per-table overrides (destination_catalog, destination_schema)
+  all_landing_targets = distinct(flatten([
     for pair in local.database_schema_pairs :
-    pair.uc_catalog => pair.uc_catalog...
+    length(pair.specific_tables) > 0 ? [
+      for t in pair.specific_tables : {
+        catalog = try(t.destination_catalog, pair.uc_catalog)
+        schema  = try(t.destination_schema, pair.destination_schema)
+      }
+    ] : [
+      { catalog = pair.uc_catalog, schema = pair.destination_schema }
+    ]
+  ]))
+
+  # Map catalog name -> list of schemas for validation (includes per-table overrides)
+  landing_catalogs_map = {
+    for catalog in distinct([for t in local.all_landing_targets : t.catalog]) :
+    catalog => distinct([for t in local.all_landing_targets : t.schema if t.catalog == catalog])
   }
 
 
   # Create database-schema pairs for ingestion pipelines
   database_schema_pairs = distinct(flatten([
     for db in local.cfg.databases : [
-      for schema in db.schemas : {
+      for i, schema in db.schemas : {
         database_name        = db.name
         schema_name          = schema.name
-        pair_key             = "${db.name}_${schema.name}"
+        pair_key             = local.is_mysql ? "${db.name}_schema_${i}" : "${db.name}_${schema.name}"   # For MySQL, concept of schema does not exist, hence handling through arbitrary index
         use_schema_ingestion = try(schema.use_schema_ingestion, true)
         specific_tables      = try(schema.tables, [])
         # For PostgreSQL: Pass replication slot and publication info if present
@@ -57,7 +73,12 @@ locals {
         # UC catalog and schema configuration for this database-schema pair
         uc_catalog = try(db.uc_catalog, local.global_uc_catalog)
         # Build destination schema name: {prefix}{source_schema_name}{suffix}
-        destination_schema = join("", [
+        # For MySQL (no schema level), use database name so one UC schema per MySQL database
+        destination_schema = local.is_mysql ? join("", [
+          try(db.schema_prefix, ""),
+          db.name,
+          try(db.schema_suffix, "")
+        ]) : join("", [
           try(db.schema_prefix, ""),
           schema.name,
           try(db.schema_suffix, "")

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -10,18 +10,13 @@ module "staging" {
   schemas      = [local.staging_schema_name]
 }
 
-# Validate catalogs and schemas where ingestion pipelines will land data
-# Group schemas by their target catalog
+# Validate catalogs and schemas where ingestion pipelines will land data (includes per-table overrides)
 module "landing_catalog_validation" {
   source   = "./modules/validate_catalog_and_schemas"
   for_each = local.landing_catalogs_map
 
   catalog_name = each.key
-  schemas = distinct([
-    for pair in local.database_schema_pairs :
-    pair.destination_schema
-    if pair.uc_catalog == each.key
-  ])
+  schemas      = each.value
 }
 
 module "gateway" {
@@ -44,14 +39,14 @@ module "ingestion" {
 
   for_each = { for pair in local.database_schema_pairs : pair.pair_key => pair }
 
-  name                  = "${each.value.database_name}-${each.value.schema_name}-ingestion"
-  source_catalog        = each.value.database_name
-  source_schema         = each.value.schema_name
+  name                  = local.is_mysql ? "${each.value.pair_key}-ingestion" : "${each.value.database_name}-${each.value.schema_name}-ingestion"
+  source_catalog        = local.is_mysql ? "default_catalog" : each.value.database_name
+  source_schema         = local.is_mysql ? each.value.database_name : each.value.schema_name
   destination_catalog   = each.value.uc_catalog
   destination_schema    = each.value.destination_schema
   gateway_pipeline_id   = module.gateway.pipeline_id
   source_type           = local.connection.source_type
-  use_schema_ingestion  = each.value.use_schema_ingestion
+  use_schema_ingestion  = local.is_mysql ? false : each.value.use_schema_ingestion # For MySQL, schema-level ingestion is not applicable hence ignore
   specific_tables       = each.value.specific_tables
   source_configurations = lookup(local.database_source_configurations, each.value.database_name, null)
   event_log_to_table    = local.event_log_to_table

--- a/infra/modules/ingestion_pipeline/main.tf
+++ b/infra/modules/ingestion_pipeline/main.tf
@@ -36,8 +36,10 @@ variable "source_type" {
 variable "specific_tables" {
   description = "List of specific tables to ingest instead of entire schema"
   type = list(object({
-    source_table        = string
-    destination_table   = optional(string) # Optional: if not provided, uses source_table
+    source_table          = string
+    destination_table     = optional(string) # Optional: if not provided, uses source_table
+    destination_catalog   = optional(string)  # Optional: if not provided, uses pipeline-level destination_catalog
+    destination_schema    = optional(string)  # Optional: if not provided, uses pipeline-level destination_schema
   }))
   default = []
 }
@@ -91,9 +93,9 @@ resource "databricks_pipeline" "ingest" {
           source_catalog      = var.source_catalog
           source_schema       = var.source_schema
           source_table        = objects.value.source_table
-          destination_catalog = var.destination_catalog
-          destination_schema  = var.destination_schema
-          destination_table   = objects.value.destination_table != null ? objects.value.destination_table : objects.value.source_table
+          destination_catalog = coalesce(objects.value.destination_catalog, var.destination_catalog)
+          destination_schema  = coalesce(objects.value.destination_schema, var.destination_schema)
+          destination_table   = coalesce(objects.value.destination_table, objects.value.source_table)
         }
       }
     }

--- a/tools/pydantic_validator.py
+++ b/tools/pydantic_validator.py
@@ -140,6 +140,18 @@ class TableConfig(BaseModel):
         ...,
         description="Source table name"
     )
+    destination_table: Optional[str] = Field(
+        default=None,
+        description="Destination table name in Unity Catalog (defaults to source_table)"
+    )
+    destination_catalog: Optional[str] = Field(
+        default=None,
+        description="Override destination catalog for this table (defaults to schema/database-level catalog)"
+    )
+    destination_schema: Optional[str] = Field(
+        default=None,
+        description="Override destination schema for this table (defaults to schema/database-level schema)"
+    )
     
     @field_validator("source_table")
     @classmethod
@@ -518,6 +530,25 @@ class LakeflowConfig(BaseModel):
         
         return self
     
+    @model_validator(mode="after")
+    def validate_mysql_schema_ingestion_warning(self):
+        """
+        For MySQL: use_schema_ingestion=true does not apply (no schema level).
+        Emit a warning when set; Terraform will ignore it and use table-level ingestion.
+        """
+        if self.connection.source_type != "MYSQL":
+            return self
+        for db in self.databases:
+            for schema in db.schemas:
+                if schema.use_schema_ingestion:
+                    print(
+                        "INFO: 'use_schema_ingestion' setting as True does not apply for MySQL. "
+                        "Ignoring and ingesting based on tables passed.",
+                        file=sys.stderr,
+                    )
+                    return self  # One warning is enough
+        return self
+
     @model_validator(mode="after")
     def validate_per_database_schedules(self):
         """


### PR DESCRIPTION
- MySQL: default_catalog/source_schema mapping, placeholder schema, table-level only
- Per-table optional destination_catalog, destination_schema, destination_table
- Use coalesce() for table destination fields to avoid null for provider
- Landing validation includes per-table overrides
- Pydantic: TableConfig optional overrides; MySQL use_schema_ingestion warning
- Remove mysql_schema_ingestion_note output; rely on validator and README
- README: MySQL example, per-table overrides, and related docs