### PR TITLE
feat(ci): GitHub Actions CI/CD setup with SPN auth and python fix

### DIFF
--- a/.github/workflows/full-refresh-pipeline.yml
+++ b/.github/workflows/full-refresh-pipeline.yml
@@ -1,0 +1,149 @@
+# =============================================================================
+# User Story A: Full Refresh of Entire Ingestion Pipeline
+# =============================================================================
+#
+# This workflow enables controlled full refresh of Lakeflow Connect ingestion
+# pipelines through CI/CD with a mandatory approval gate.
+#
+# How it works:
+#   1. User triggers workflow manually (workflow_dispatch) selecting a pipeline
+#   2. A validation job checks inputs and shows what will be refreshed
+#   3. The refresh job requires approval from the "production-refresh" environment
+#   4. Once approved, the pipeline full refresh is triggered via Databricks API
+#      and runs asynchronously (fire-and-forget — monitor progress in Databricks UI)
+#
+# Prerequisites:
+#   - GitHub Environment "production-refresh" with required reviewers configured
+#   - Repository secrets: DATABRICKS_HOST, DATABRICKS_TOKEN
+#   - Terraform outputs available (pipeline IDs)
+# =============================================================================
+
+name: "Full Refresh - Entire Pipeline"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline_id:
+        description: "Databricks Pipeline ID to full refresh"
+        required: true
+        type: string
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      reason:
+        description: "Business reason for full refresh (required for audit trail)"
+        required: true
+        type: string
+
+# Ensure only one full refresh runs at a time per pipeline
+concurrency:
+  group: full-refresh-${{ github.event.inputs.pipeline_id }}
+  cancel-in-progress: false
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Job 1: Validate inputs and display refresh plan
+  # -------------------------------------------------------------------------
+  validate:
+    name: "Validate & Plan"
+    runs-on: self-hosted
+    outputs:
+      pipeline_id: ${{ github.event.inputs.pipeline_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Display refresh plan
+        run: |
+          echo "============================================"
+          echo "  FULL PIPELINE REFRESH - VALIDATION"
+          echo "============================================"
+          echo ""
+          echo "Pipeline ID:    ${{ github.event.inputs.pipeline_id }}"
+          echo "Environment:    ${{ github.event.inputs.environment }}"
+          echo "Requested by:   ${{ github.actor }}"
+          echo "Reason:         ${{ github.event.inputs.reason }}"
+          echo ""
+          echo "============================================"
+          echo "  ⚠️  This will FULL REFRESH the entire pipeline"
+          echo "  All tables will be re-ingested from source"
+          echo "  The refresh runs asynchronously - monitor in Databricks UI"
+          echo "============================================"
+
+      - name: Validate pipeline ID format
+        run: |
+          PIPELINE_ID="${{ github.event.inputs.pipeline_id }}"
+          if [[ -z "$PIPELINE_ID" ]]; then
+            echo "ERROR: Pipeline ID cannot be empty"
+            exit 1
+          fi
+          # Basic UUID-like format check
+          if [[ ! "$PIPELINE_ID" =~ ^[a-f0-9-]+$ ]]; then
+            echo "ERROR: Pipeline ID does not appear to be a valid format: $PIPELINE_ID"
+            exit 1
+          fi
+          echo "Pipeline ID format validated: $PIPELINE_ID"
+
+  # -------------------------------------------------------------------------
+  # Job 2: Execute refresh (requires approval)
+  # -------------------------------------------------------------------------
+  refresh:
+    name: "Execute Full Refresh"
+    needs: validate
+    runs-on: self-hosted
+    # NOTE: For approval gates, configure a GitHub Environment with required
+    # reviewers (requires GitHub Pro/Team/Enterprise for private repos).
+    # Uncomment when available:
+    #   environment:
+    #     name: production-refresh
+    #     url: ${{ format('https://{0}/#job/{1}/pipelines/{2}', secrets.DATABRICKS_HOST, github.run_id, github.event.inputs.pipeline_id) }}
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      # Databricks SDK Azure service principal auth (same SPN used by Terraform provider)
+      ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --break-system-packages databricks-sdk -q
+
+      - name: Create audit log entry
+        run: |
+          echo "AUDIT: Full pipeline refresh initiated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Pipeline ID | \`${{ github.event.inputs.pipeline_id }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Environment | ${{ github.event.inputs.environment }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Requested by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Approved via | GitHub Environment Protection Rules |" >> $GITHUB_STEP_SUMMARY
+          echo "| Reason | ${{ github.event.inputs.reason }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Run ID | ${{ github.run_id }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger full refresh
+        id: refresh
+        run: |
+          python3 tools/trigger_full_refresh.py \
+            --pipeline-id "${{ github.event.inputs.pipeline_id }}" \
+            --mode full
+
+      - name: Report result
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Result" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.refresh.outcome }}" == "success" ]]; then
+            echo "Full refresh triggered successfully. Monitor progress in the Databricks UI." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Full refresh FAILED to trigger. Check the logs above for details." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/full-refresh-pipeline.yml
+++ b/.github/workflows/full-refresh-pipeline.yml
@@ -14,7 +14,7 @@
 #
 # Prerequisites:
 #   - GitHub Environment "production-refresh" with required reviewers configured
-#   - Repository secrets: DATABRICKS_HOST, DATABRICKS_TOKEN
+#   - Repository secrets: DATABRICKS_HOST, DEPLOY_SPN_CLIENT_ID, DEPLOY_SPN_CLIENT_SECRET, ARM_TENANT_ID
 #   - Terraform outputs available (pipeline IDs)
 # =============================================================================
 

--- a/.github/workflows/full-refresh-pipeline.yml
+++ b/.github/workflows/full-refresh-pipeline.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --break-system-packages databricks-sdk -q
+          python -m pip install --break-system-packages databricks-sdk -q
 
       - name: Create audit log entry
         run: |
@@ -133,7 +133,7 @@ jobs:
       - name: Trigger full refresh
         id: refresh
         run: |
-          python3 tools/trigger_full_refresh.py \
+          python tools/trigger_full_refresh.py \
             --pipeline-id "${{ github.event.inputs.pipeline_id }}" \
             --mode full
 

--- a/.github/workflows/full-refresh-tables.yml
+++ b/.github/workflows/full-refresh-tables.yml
@@ -1,0 +1,240 @@
+# =============================================================================
+# User Story B: Full Refresh of Specific Tables in an Ingestion Pipeline
+# =============================================================================
+#
+# This workflow enables controlled full refresh of SPECIFIC TABLES within a
+# Lakeflow Connect ingestion pipeline through CI/CD with a mandatory approval.
+#
+# How it works:
+#   1. User triggers workflow manually selecting pipeline + specific tables
+#   2. Validation job checks table name format and verifies each table exists
+#      in Unity Catalog (fail-fast before any refresh is triggered)
+#   3. The refresh job requires approval from the "production-refresh" environment
+#   4. Once approved, a selective table full refresh is triggered via Databricks API
+#      and runs asynchronously (fire-and-forget — monitor progress in Databricks UI)
+#
+# Table name format:
+#   - Two-part:   schema.table             (catalog resolved from pipeline config)
+#   - Three-part: catalog.schema.table     (used as-is)
+#
+# Key difference from User Story A:
+#   - Uses `full_refresh_selection` API parameter instead of `full_refresh`
+#   - Only the specified tables are fully refreshed; other tables continue CDC
+#
+# Prerequisites:
+#   - GitHub Environment "production-refresh" with required reviewers configured
+#   - Repository secrets: DATABRICKS_HOST, DEPLOY_SPN_CLIENT_ID/SECRET, ARM_TENANT_ID
+#   - Terraform outputs available (pipeline IDs)
+# =============================================================================
+
+name: "Full Refresh - Specific Tables"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline_id:
+        description: "Databricks Pipeline ID containing the tables"
+        required: true
+        type: string
+      tables:
+        description: "Comma-separated table names (schema.table or catalog.schema.table)"
+        required: true
+        type: string
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      reason:
+        description: "Business reason for full refresh (required for audit trail)"
+        required: true
+        type: string
+
+# Ensure only one full refresh runs at a time per pipeline
+concurrency:
+  group: full-refresh-${{ github.event.inputs.pipeline_id }}
+  cancel-in-progress: false
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Job 1: Validate inputs — format check + verify tables exist in UC
+  # -------------------------------------------------------------------------
+  validate:
+    name: "Validate & Plan"
+    runs-on: self-hosted
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+    outputs:
+      pipeline_id: ${{ github.event.inputs.pipeline_id }}
+      table_count: ${{ steps.parse.outputs.table_count }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse and validate table name format
+        id: parse
+        run: |
+          echo "============================================"
+          echo "  SELECTIVE TABLE REFRESH - VALIDATION"
+          echo "============================================"
+          echo ""
+          echo "Pipeline ID:    ${{ github.event.inputs.pipeline_id }}"
+          echo "Environment:    ${{ github.event.inputs.environment }}"
+          echo "Requested by:   ${{ github.actor }}"
+          echo "Reason:         ${{ github.event.inputs.reason }}"
+          echo ""
+
+          PIPELINE_ID="${{ github.event.inputs.pipeline_id }}"
+          if [[ -z "$PIPELINE_ID" ]]; then
+            echo "ERROR: Pipeline ID cannot be empty"
+            exit 1
+          fi
+          if [[ ! "$PIPELINE_ID" =~ ^[a-f0-9-]+$ ]]; then
+            echo "ERROR: Pipeline ID does not appear to be a valid format: $PIPELINE_ID"
+            exit 1
+          fi
+
+          IFS=',' read -ra TABLES <<< "${{ github.event.inputs.tables }}"
+          TABLE_COUNT=${#TABLES[@]}
+          echo "table_count=$TABLE_COUNT" >> $GITHUB_OUTPUT
+
+          echo "Tables requested ($TABLE_COUNT):"
+          for table in "${TABLES[@]}"; do
+            table=$(echo "$table" | xargs)
+            PARTS=$(echo "$table" | tr '.' '\n' | wc -l)
+            if [[ $PARTS -lt 2 || $PARTS -gt 3 ]]; then
+              echo "ERROR: '$table' must be schema.table or catalog.schema.table"
+              exit 1
+            fi
+            echo "  - $table"
+          done
+
+          echo ""
+          echo "============================================"
+          echo "  Only the above tables will be fully refreshed."
+          echo "  Other tables in the pipeline will continue CDC."
+          echo "============================================"
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --break-system-packages databricks-sdk -q
+
+      - name: Verify tables exist in Unity Catalog
+        run: |
+          python3 - <<'EOF'
+          import sys
+          from databricks.sdk import WorkspaceClient
+          from databricks.sdk.errors import NotFound
+
+          pipeline_id = "${{ github.event.inputs.pipeline_id }}"
+          tables_input = "${{ github.event.inputs.tables }}"
+
+          client = WorkspaceClient()
+
+          # Get pipeline target catalog for resolving two-part names
+          pipeline = client.pipelines.get(pipeline_id=pipeline_id)
+          pipeline_catalog = pipeline.spec.catalog if pipeline.spec else None
+          print(f"Pipeline: {pipeline.name}")
+          print(f"Target catalog: {pipeline_catalog or '(none)'}")
+          print()
+
+          tables = [t.strip() for t in tables_input.split(",") if t.strip()]
+          errors = []
+
+          for table in tables:
+              parts = table.split(".")
+              if len(parts) == 2:
+                  if not pipeline_catalog:
+                      errors.append(f"'{table}': two-part name but pipeline has no target catalog")
+                      continue
+                  full_name = f"{pipeline_catalog}.{table}"
+              else:
+                  full_name = table
+
+              try:
+                  # Unity Catalog stores identifiers as lowercase
+                  client.tables.get(full_name=full_name.lower())
+                  print(f"  OK  {full_name}")
+              except NotFound:
+                  errors.append(f"'{full_name}' not found in Unity Catalog")
+              except Exception as e:
+                  errors.append(f"'{full_name}' lookup failed: {e}")
+
+          if errors:
+              print("\nFailed — the following tables were not found in Unity Catalog:")
+              for err in errors:
+                  print(f"  X  {err}")
+              print(f"\nHint: Use the UC schema name as it appears in Unity Catalog under '{pipeline_catalog}'.")
+              print("      Schema prefixes/suffixes from the pipeline config are applied (e.g. 'orapdb1_client_management', not 'client_management').")
+              print("      Use the 'List Pipeline IDs' workflow to confirm pipeline details, or browse UC in the Databricks UI.")
+              sys.exit(1)
+
+          print(f"\nAll {len(tables)} table(s) verified in Unity Catalog.")
+          EOF
+
+  # -------------------------------------------------------------------------
+  # Job 2: Execute selective refresh (requires approval)
+  # -------------------------------------------------------------------------
+  refresh:
+    name: "Execute Selective Table Refresh"
+    needs: validate
+    runs-on: self-hosted
+    # NOTE: For approval gates, configure a GitHub Environment with required
+    # reviewers (requires GitHub Pro/Team/Enterprise for private repos).
+    # Uncomment when available:
+    #   environment:
+    #     name: production-refresh
+    #     url: ${{ format('https://{0}/#job/{1}/pipelines/{2}', secrets.DATABRICKS_HOST, github.run_id, github.event.inputs.pipeline_id) }}
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --break-system-packages databricks-sdk -q
+
+      - name: Create audit log entry
+        run: |
+          echo "AUDIT: Selective table refresh initiated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Pipeline ID | \`${{ github.event.inputs.pipeline_id }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tables | ${{ github.event.inputs.tables }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Table Count | ${{ needs.validate.outputs.table_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Environment | ${{ github.event.inputs.environment }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Requested by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Approved via | GitHub Environment Protection Rules |" >> $GITHUB_STEP_SUMMARY
+          echo "| Reason | ${{ github.event.inputs.reason }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Run ID | ${{ github.run_id }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger selective table refresh
+        id: refresh
+        run: |
+          python3 tools/trigger_full_refresh.py \
+            --pipeline-id "${{ github.event.inputs.pipeline_id }}" \
+            --mode tables \
+            --tables "${{ github.event.inputs.tables }}"
+
+      - name: Report result
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Result" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.refresh.outcome }}" == "success" ]]; then
+            echo "Selective table refresh triggered successfully. Monitor progress in the Databricks UI." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Selective table refresh FAILED to trigger. Check the logs above for details." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/full-refresh-tables.yml
+++ b/.github/workflows/full-refresh-tables.yml
@@ -123,11 +123,11 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --break-system-packages databricks-sdk -q
+          python -m pip install --break-system-packages databricks-sdk -q
 
       - name: Verify tables exist in Unity Catalog
         run: |
-          python3 - <<'EOF'
+          python - <<'EOF'
           import sys
           from databricks.sdk import WorkspaceClient
           from databricks.sdk.errors import NotFound
@@ -202,7 +202,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --break-system-packages databricks-sdk -q
+          python -m pip install --break-system-packages databricks-sdk -q
 
       - name: Create audit log entry
         run: |
@@ -223,7 +223,7 @@ jobs:
       - name: Trigger selective table refresh
         id: refresh
         run: |
-          python3 tools/trigger_full_refresh.py \
+          python tools/trigger_full_refresh.py \
             --pipeline-id "${{ github.event.inputs.pipeline_id }}" \
             --mode tables \
             --tables "${{ github.event.inputs.tables }}"

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -1,0 +1,323 @@
+# =============================================================================
+# Terraform Deployment Workflow for Lakeflow Connect Pipelines
+# =============================================================================
+#
+# Deploys Lakeflow Connect infrastructure (gateway pipeline, ingestion
+# pipelines, orchestration jobs) to a Databricks workspace using Terraform.
+#
+# Flow:
+#   1. On push to main: runs validate + plan automatically
+#   2. On manual trigger: runs validate + plan + apply (with approval gate)
+#   3. Plan output is posted to the workflow summary for review
+#   4. Apply requires approval via the "production-deploy" environment
+#
+# Config file: config/lakeflow_dev.yml
+#
+# Self-hosted runner prerequisites: python3, pip3, terraform
+#
+# Authentication model (two separate SPNs):
+#   TF_STATE_SPN  - Azure SP with Storage Blob Data Contributor on tf-state
+#                   container. Used ONLY for terraform init (azurerm backend).
+#   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
+#                   principal. Used for terraform plan/apply (Databricks provider).
+#
+# NOTE on artifact approach:
+#   The ideal pattern is to save the terraform plan as a GitHub artifact
+#   (actions/upload-artifact) in the plan job, then download it in the apply
+#   job. This guarantees that exactly what was reviewed gets applied. However,
+#   this requires GitHub Actions artifact storage quota to be available.
+#   If your GitHub environment supports artifacts, you can restore the
+#   artifact-based approach by:
+#     1. Splitting plan-and-apply back into separate plan + apply jobs
+#     2. Using actions/upload-artifact@v4 after terraform plan -out=tfplan
+#     3. Using actions/download-artifact@v4 before terraform apply tfplan
+#   The current approach runs plan + apply in the same job, with the
+#   approval gate (GitHub Environment) between validate and plan-and-apply.
+# =============================================================================
+
+name: "Terraform Deploy - Lakeflow Connect"
+
+on:
+  # Auto-run plan on push to main (when infra or config changes)
+  push:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - "config/**"
+      - "tools/**"
+
+  # Manual trigger for full deploy (plan + apply)
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        type: choice
+        options:
+          - plan-only
+          - plan-and-apply
+          - destroy
+      config_file:
+        description: "Path to YAML config file"
+        required: true
+        type: string
+        default: "../config/lakeflow_dev.yml"
+
+# Only one deployment at a time
+concurrency:
+  group: terraform-deploy
+  cancel-in-progress: false
+
+env:
+  TF_WORKING_DIR: infra
+  YAML_CONFIG_PATH: "../config/lakeflow_dev.yml"
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Job 1: Validate config and Terraform files
+  # -------------------------------------------------------------------------
+  validate:
+    name: "Validate"
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install pydantic pyyaml croniter
+
+      - name: Validate YAML config with Pydantic
+        run: |
+          source .venv/bin/activate
+          CONFIG_PATH="${{ github.event.inputs.config_file || 'config/lakeflow_dev.yml' }}"
+          # Adjust path for validator (it expects path relative to repo root)
+          if [[ "$CONFIG_PATH" == ../config/* ]]; then
+            CONFIG_PATH="config/${CONFIG_PATH#../config/}"
+          fi
+          echo "Validating config: $CONFIG_PATH"
+          python3 tools/pydantic_validator.py "$CONFIG_PATH"
+
+      - name: Terraform Format Check
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+      - name: Terraform Validate
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform validate
+
+  # -------------------------------------------------------------------------
+  # Job 2: Terraform Plan (always runs)
+  # -------------------------------------------------------------------------
+  plan:
+    name: "Plan"
+    needs: validate
+    runs-on: self-hosted
+    outputs:
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install databricks-sdk pyyaml
+
+      - name: Terraform Init and Plan
+        id: plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          # DEPLOY_SPN credentials as ARM_* — used by Databricks provider for
+          # azure-client-secret auth during plan. Also provides subscription ID.
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          set -o pipefail
+
+          # Init with TF_STATE_SPN credentials via -backend-config (overrides ARM_* env vars)
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+          CONFIG_PATH="${{ github.event.inputs.config_file || env.YAML_CONFIG_PATH }}"
+
+          # Determine if this is a destroy
+          DESTROY_FLAG=""
+          if [[ "${{ github.event.inputs.action }}" == "destroy" ]]; then
+            DESTROY_FLAG="-destroy"
+          fi
+
+          # Plan uses ARM_* env vars (DEPLOY_SPN) for Databricks provider auth
+          terraform plan \
+            -var="yaml_config_path=${CONFIG_PATH}" \
+            -input=false \
+            $DESTROY_FLAG \
+            -no-color 2>&1 | tee plan_output.txt
+
+          # Check if there are changes
+          if grep -q "No changes" plan_output.txt; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post plan to summary
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          echo "## Terraform Plan Output" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Config file**: \`${{ github.event.inputs.config_file || env.YAML_CONFIG_PATH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Action**: \`${{ github.event.inputs.action || 'plan-only (auto)' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat plan_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      # NOTE: Artifact-based approach (recommended when GitHub artifact storage is available):
+      # Saving the plan file as an artifact ensures the exact reviewed plan is applied.
+      # Uncomment the block below and split apply into a separate job that downloads it.
+      #
+      # - name: Upload plan artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: tfplan
+      #     path: ${{ env.TF_WORKING_DIR }}/tfplan
+      #     retention-days: 1
+
+  # -------------------------------------------------------------------------
+  # Job 3: Terraform Apply
+  # Runs init + plan + apply in the same job.
+  # NOTE: For approval gates, configure a GitHub Environment with required
+  # reviewers (requires GitHub Pro/Team/Enterprise for private repos).
+  # Uncomment the 'environment' block below when available:
+  #   environment:
+  #     name: production-deploy
+  # -------------------------------------------------------------------------
+  apply:
+    name: "Apply"
+    needs: plan
+    # Only run apply when manually triggered with plan-and-apply or destroy
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.action == 'plan-and-apply' || github.event.inputs.action == 'destroy') &&
+      needs.plan.outputs.has_changes == 'true'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python dependencies for local-exec
+        run: |
+          pip3 install --break-system-packages databricks-sdk pyyaml
+
+      - name: Terraform Init, Plan, and Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          # DEPLOY_SPN credentials as ARM_* — used by Databricks provider for
+          # azure-client-secret auth. Also provides subscription ID.
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          set -o pipefail
+
+          echo "## Terraform Apply" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Action | ${{ github.event.inputs.action }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Config | \`${{ github.event.inputs.config_file }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Approved by | Environment protection rules |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Init with TF_STATE_SPN credentials via -backend-config
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+          CONFIG_PATH="${{ github.event.inputs.config_file || env.YAML_CONFIG_PATH }}"
+
+          DESTROY_FLAG=""
+          if [[ "${{ github.event.inputs.action }}" == "destroy" ]]; then
+            DESTROY_FLAG="-destroy"
+          fi
+
+          # Plan and save to file, then apply
+          terraform plan \
+            -var="yaml_config_path=${CONFIG_PATH}" \
+            -out=tfplan \
+            -input=false \
+            $DESTROY_FLAG \
+            -no-color
+
+          terraform apply -input=false -no-color tfplan 2>&1 | tee apply_output.txt
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat apply_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Show outputs
+        if: github.event.inputs.action == 'plan-and-apply'
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployed Resources" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "**Gateway Pipeline ID:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`$(terraform output -raw gateway_pipeline_id 2>/dev/null || echo 'N/A')\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "**Ingestion Pipeline IDs:**" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          terraform output -json ingestion_pipeline_id_map 2>/dev/null || echo '{}'
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  # -------------------------------------------------------------------------
+  # Job 4: No changes notification
+  # -------------------------------------------------------------------------
+  no-changes:
+    name: "No Changes"
+    needs: plan
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.action == 'plan-and-apply' || github.event.inputs.action == 'destroy') &&
+      needs.plan.outputs.has_changes == 'false'
+    runs-on: self-hosted
+    steps:
+      - name: Report no changes
+        run: |
+          echo "## No Changes Detected" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Terraform plan found no changes to apply. Infrastructure is up to date." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -13,7 +13,7 @@
 #
 # Config file: config/lakeflow_dev.yml
 #
-# Self-hosted runner prerequisites: python3, pip3, terraform
+# Self-hosted runner prerequisites: python, pip3, terraform
 #
 # Authentication model (two separate SPNs):
 #   TF_STATE_SPN  - Azure SP with Storage Blob Data Contributor on tf-state
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set up Python venv and install dependencies
         run: |
-          python3 -m venv .venv
+          python -m venv .venv
           source .venv/bin/activate
           pip install pydantic pyyaml croniter
 
@@ -101,7 +101,7 @@ jobs:
             CONFIG_PATH="config/${CONFIG_PATH#../config/}"
           fi
           echo "Validating config: $CONFIG_PATH"
-          python3 tools/pydantic_validator.py "$CONFIG_PATH"
+          python tools/pydantic_validator.py "$CONFIG_PATH"
 
       - name: Terraform Format Check
         working-directory: ${{ env.TF_WORKING_DIR }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Set up Python venv and install dependencies
         run: |
-          python3 -m venv .venv
+          python -m venv .venv
           source .venv/bin/activate
           pip install databricks-sdk pyyaml
 

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -21,6 +21,9 @@
 #   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
 #                   principal. Used for terraform plan/apply (Databricks provider).
 #
+# Repository variables (azurerm partial backend — state blob location):
+#   TF_STATE_RESOURCE_GROUP, TF_STATE_STORAGE_ACCOUNT, TF_STATE_CONTAINER, TF_STATE_KEY
+#
 # NOTE on artifact approach:
 #   The ideal pattern is to save the terraform plan as a GitHub artifact
 #   (actions/upload-artifact) in the plan job, then download it in the apply
@@ -108,6 +111,11 @@ jobs:
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: |
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
@@ -152,6 +160,11 @@ jobs:
 
           # Init with TF_STATE_SPN credentials via -backend-config (overrides ARM_* env vars)
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
@@ -255,6 +268,11 @@ jobs:
 
           # Init with TF_STATE_SPN credentials via -backend-config
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \

--- a/.github/workflows/terraform-output-pipeline-ids.yml
+++ b/.github/workflows/terraform-output-pipeline-ids.yml
@@ -68,7 +68,7 @@ jobs:
           echo "| Pipeline Key | Pipeline ID |" >> $GITHUB_STEP_SUMMARY
           echo "|-------------|-------------|" >> $GITHUB_STEP_SUMMARY
           terraform output -json ingestion_pipeline_id_map 2>/dev/null | \
-            python3 -c "
+            python -c "
           import json, sys
           data = json.load(sys.stdin)
           for key, pid in sorted(data.items()):

--- a/.github/workflows/terraform-output-pipeline-ids.yml
+++ b/.github/workflows/terraform-output-pipeline-ids.yml
@@ -1,0 +1,71 @@
+# =============================================================================
+# Helper Workflow: List Pipeline IDs from Terraform State
+# =============================================================================
+#
+# This workflow retrieves and displays all pipeline IDs from Terraform state,
+# making it easy for users to find the correct pipeline ID before triggering
+# a full refresh workflow.
+#
+# This is a read-only operation and does NOT require approval.
+# =============================================================================
+
+name: "List Pipeline IDs"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+
+jobs:
+  list-pipelines:
+    name: "Retrieve Pipeline IDs"
+    runs-on: self-hosted
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Terraform Init
+        working-directory: infra
+        run: |
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+      - name: Get Pipeline IDs
+        working-directory: infra
+        run: |
+          echo "## Pipeline IDs for ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Gateway Pipeline" >> $GITHUB_STEP_SUMMARY
+          GATEWAY_ID=$(terraform output -raw gateway_pipeline_id 2>/dev/null || echo "N/A")
+          echo "| Pipeline | ID |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| Gateway | \`$GATEWAY_ID\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Ingestion Pipelines" >> $GITHUB_STEP_SUMMARY
+          echo "| Pipeline Key | Pipeline ID |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------------|-------------|" >> $GITHUB_STEP_SUMMARY
+          terraform output -json ingestion_pipeline_id_map 2>/dev/null | \
+            python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          for key, pid in sorted(data.items()):
+              print(f'| \`{key}\` | \`{pid}\` |')
+          " >> $GITHUB_STEP_SUMMARY || echo "| N/A | Could not retrieve |" >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "*Use these pipeline IDs when triggering full refresh workflows.*" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-output-pipeline-ids.yml
+++ b/.github/workflows/terraform-output-pipeline-ids.yml
@@ -7,6 +7,9 @@
 # a full refresh workflow.
 #
 # This is a read-only operation and does NOT require approval.
+#
+# Repository variables (azurerm partial backend — state blob location):
+#   TF_STATE_RESOURCE_GROUP, TF_STATE_STORAGE_ACCOUNT, TF_STATE_CONTAINER, TF_STATE_KEY
 # =============================================================================
 
 name: "List Pipeline IDs"
@@ -38,6 +41,11 @@ jobs:
         working-directory: infra
         run: |
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \

--- a/.github/workflows/terraform-output-pipeline-ids.yml
+++ b/.github/workflows/terraform-output-pipeline-ids.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: self-hosted
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/terraform-release.yml
+++ b/.github/workflows/terraform-release.yml
@@ -1,0 +1,321 @@
+# =============================================================================
+# Terraform Release Workflow — Tag-Triggered Plan + Apply
+# =============================================================================
+#
+# Deploys Lakeflow Connect infrastructure via a full Terraform plan-and-apply
+# cycle, triggered automatically when a semver tag is pushed to the tip of main.
+#
+# Trigger:
+#   Push a tag matching v<major>.<minor>.<patch> (e.g. v1.0.0) while the tagged
+#   commit IS the current HEAD of main.  A guard step aborts the run if the tag
+#   points at any other commit, preventing accidental deploys from old history.
+#
+# Flow:
+#   1. validate   — Pydantic config check + terraform fmt/init/validate
+#   2. plan       — terraform plan, output posted to workflow summary
+#   3. apply      — terraform plan -out=tfplan → apply tfplan (same job,
+#                   so the exact reviewed plan is what gets applied)
+#   4. no-changes — informational job when plan finds nothing to do
+#
+# Rollback to an older release:
+# -----------------------------------------------------------------------
+#   IMPORTANT: The guard step enforces that a tag must point at the tip
+#   of main. You CANNOT roll back by tagging an old commit — the guard
+#   will abort the run. Instead, use one of the approaches below.
+#
+#   Option A — Git revert on main (recommended, keeps history clean):
+#     1. Identify the commit(s) to undo:
+#            git log --oneline --decorate origin/main
+#     2. Revert them — this creates a NEW commit on main:
+#            git revert <bad-sha>..HEAD   # range, or a single SHA
+#            git push origin main
+#     3. Tag the new tip of main with the next semver:
+#            git tag v1.0.2
+#            git push origin v1.0.2
+#        The guard passes (tag = new tip of main). Terraform computes
+#        the diff from current deployed state to the reverted config
+#        and converges. History stays linear and auditable.
+#
+#   Option B — Manual workflow_dispatch on terraform-deploy.yml:
+#     Bypass the tag flow entirely.
+#     1. Create a branch from the old tag you want to redeploy:
+#            git checkout -b rollback/v1.0.0 v1.0.0
+#            git push origin rollback/v1.0.0
+#     2. In GitHub: Actions → Terraform Deploy → Run workflow,
+#        select action=plan-and-apply. This runs against that branch's
+#        config with no guard involved.
+#
+#   In both cases Terraform computes a diff from current deployed state
+#   to the desired older state and converges to it. No manual state
+#   manipulation is required.
+# -----------------------------------------------------------------------
+#
+# Config file: config/lakeflow_dev.yml
+#
+# Authentication model (two separate SPNs):
+#   TF_STATE_SPN  - Azure SP with Storage Blob Data Contributor on tf-state
+#                   container. Used ONLY for terraform init (azurerm backend).
+#   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
+#                   principal. Used for terraform plan/apply (Databricks provider).
+# =============================================================================
+
+name: "Terraform Release - Tag Triggered"
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+# Only one release deploy at a time — never cancel in progress
+concurrency:
+  group: terraform-release
+  cancel-in-progress: false
+
+env:
+  TF_WORKING_DIR: infra
+  YAML_CONFIG_PATH: "../config/lakeflow_dev.yml"
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Job 1: Guard — ensure the tag points at the tip of main
+  # -------------------------------------------------------------------------
+  guard:
+    name: "Guard: Tag must be tip of main"
+    runs-on: self-hosted
+    outputs:
+      tag_version: ${{ steps.meta.outputs.tag_version }}
+    steps:
+      - name: Checkout repository (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on tip of main
+        id: meta
+        run: |
+          TAG_SHA=$(git rev-parse "${{ github.ref }}")
+          MAIN_SHA=$(git rev-parse origin/main)
+
+          echo "Tagged commit : $TAG_SHA"
+          echo "Tip of main   : $MAIN_SHA"
+          echo "Tag name      : ${{ github.ref_name }}"
+
+          if [[ "$TAG_SHA" != "$MAIN_SHA" ]]; then
+            echo ""
+            echo "ERROR: Tag ${{ github.ref_name }} points at $TAG_SHA"
+            echo "       but origin/main is at $MAIN_SHA."
+            echo "       Release tags must be placed on the tip of main."
+            echo "       Delete the tag and re-tag the correct commit."
+            exit 1
+          fi
+
+          echo "tag_version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "Tag is on tip of main. Proceeding with release."
+
+  # -------------------------------------------------------------------------
+  # Job 2: Validate config and Terraform files
+  # -------------------------------------------------------------------------
+  validate:
+    name: "Validate"
+    needs: guard
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install pydantic pyyaml croniter
+
+      - name: Validate YAML config with Pydantic
+        run: |
+          source .venv/bin/activate
+          echo "Validating config: config/lakeflow_dev.yml"
+          python3 tools/pydantic_validator.py "config/lakeflow_dev.yml"
+
+      - name: Terraform Format Check
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+      - name: Terraform Validate
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform validate
+
+  # -------------------------------------------------------------------------
+  # Job 3: Terraform Plan
+  # -------------------------------------------------------------------------
+  plan:
+    name: "Plan"
+    needs: [guard, validate]
+    runs-on: self-hosted
+    outputs:
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install databricks-sdk pyyaml
+
+      - name: Terraform Init and Plan
+        id: plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          set -o pipefail
+
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+          terraform plan \
+            -var="yaml_config_path=${{ env.YAML_CONFIG_PATH }}" \
+            -input=false \
+            -no-color 2>&1 | tee plan_output.txt
+
+          if grep -q "No changes" plan_output.txt; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post plan to summary
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          echo "## Terraform Plan — Release ${{ needs.guard.outputs.tag_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Release tag | \`${{ needs.guard.outputs.tag_version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Config file | \`config/lakeflow_dev.yml\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat plan_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  # -------------------------------------------------------------------------
+  # Job 4: Terraform Apply (runs only when plan has changes)
+  # -------------------------------------------------------------------------
+  apply:
+    name: "Apply"
+    needs: [guard, plan]
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: self-hosted
+    # NOTE: Uncomment the block below to add a human approval gate before apply.
+    # Requires a GitHub Environment named "production-deploy" with required reviewers
+    # configured (needs GitHub Pro/Team/Enterprise for private repos).
+    #   environment:
+    #     name: production-deploy
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python dependencies for local-exec
+        run: |
+          pip3 install --break-system-packages databricks-sdk pyyaml
+
+      - name: Terraform Init, Plan, and Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          set -o pipefail
+
+          echo "## Terraform Apply — Release ${{ needs.guard.outputs.tag_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Release tag | \`${{ needs.guard.outputs.tag_version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Config file | \`config/lakeflow_dev.yml\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          terraform init \
+            -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
+            -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
+            -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
+            -backend-config="tenant_id=${{ secrets.ARM_TENANT_ID }}"
+
+          # Plan to file, then apply exactly that plan
+          terraform plan \
+            -var="yaml_config_path=${{ env.YAML_CONFIG_PATH }}" \
+            -out=tfplan \
+            -input=false \
+            -no-color
+
+          terraform apply -input=false -no-color tfplan 2>&1 | tee apply_output.txt
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat apply_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Show deployed resource IDs
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployed Resources" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "**Gateway Pipeline ID:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`$(terraform output -raw gateway_pipeline_id 2>/dev/null || echo 'N/A')\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "**Ingestion Pipeline IDs:**" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          terraform output -json ingestion_pipeline_id_map 2>/dev/null || echo '{}'
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "Tag [\`${{ needs.guard.outputs.tag_version }}\`](https://github.com/${{ github.repository }}/releases/tag/${{ needs.guard.outputs.tag_version }}) deployed successfully." >> $GITHUB_STEP_SUMMARY
+
+  # -------------------------------------------------------------------------
+  # Job 5: No changes notification
+  # -------------------------------------------------------------------------
+  no-changes:
+    name: "No Changes"
+    needs: [guard, plan]
+    if: needs.plan.outputs.has_changes == 'false'
+    runs-on: self-hosted
+    steps:
+      - name: Report no changes
+        run: |
+          echo "## No Changes — Release ${{ needs.guard.outputs.tag_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Terraform plan found no infrastructure changes for tag \`${{ needs.guard.outputs.tag_version }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "The deployed infrastructure already matches the configuration at this commit." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-release.yml
+++ b/.github/workflows/terraform-release.yml
@@ -57,6 +57,9 @@
 #                   container. Used ONLY for terraform init (azurerm backend).
 #   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
 #                   principal. Used for terraform plan/apply (Databricks provider).
+#
+# Repository variables (azurerm partial backend — state blob location):
+#   TF_STATE_RESOURCE_GROUP, TF_STATE_STORAGE_ACCOUNT, TF_STATE_CONTAINER, TF_STATE_KEY
 # =============================================================================
 
 name: "Terraform Release - Tag Triggered"
@@ -143,6 +146,11 @@ jobs:
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: |
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
@@ -184,6 +192,11 @@ jobs:
           set -o pipefail
 
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \
@@ -260,6 +273,11 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
+            -backend-config="key=${{ vars.TF_STATE_KEY }}" \
+            -backend-config="use_azuread_auth=true" \
             -backend-config="client_id=${{ secrets.TF_STATE_ARM_CLIENT_ID }}" \
             -backend-config="client_secret=${{ secrets.TF_STATE_ARM_CLIENT_SECRET }}" \
             -backend-config="subscription_id=${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}" \

--- a/.github/workflows/terraform-release.yml
+++ b/.github/workflows/terraform-release.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Set up Python venv and install dependencies
         run: |
-          python3 -m venv .venv
+          python -m venv .venv
           source .venv/bin/activate
           pip install pydantic pyyaml croniter
 
@@ -136,7 +136,7 @@ jobs:
         run: |
           source .venv/bin/activate
           echo "Validating config: config/lakeflow_dev.yml"
-          python3 tools/pydantic_validator.py "config/lakeflow_dev.yml"
+          python tools/pydantic_validator.py "config/lakeflow_dev.yml"
 
       - name: Terraform Format Check
         working-directory: ${{ env.TF_WORKING_DIR }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: Set up Python venv and install dependencies
         run: |
-          python3 -m venv .venv
+          python -m venv .venv
           source .venv/bin/activate
           pip install databricks-sdk pyyaml
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,73 @@ poetry run terraform apply --var yaml_config_path=../config/lakeflow_<env>.yml
 
 **Note:** While `terraform plan` does not require `poetry run` (since the gateway validation Python script is executed only during `apply`), we recommend using `poetry run` for both `plan` and `apply` to provide a consistent workflow and environment.
 
+## GitHub Actions CI/CD Setup
+
+This repository ships with five GitHub Actions workflows that run on a **self-hosted runner** and automate the full deployment and refresh lifecycle.
+
+### Workflows Overview
+
+| Workflow file | Trigger | Purpose |
+|---------------|---------|---------|
+| `terraform-deploy.yml` | Push to `main` (auto plan) or `workflow_dispatch` | Validate → Plan → Apply (with optional approval gate) |
+| `terraform-release.yml` | Semver tag push (e.g. `v1.0.0`) | Tag-gated Validate → Plan → Apply; tag must be tip of `main` |
+| `terraform-output-pipeline-ids.yml` | `workflow_dispatch` | Read-only: list all pipeline IDs from Terraform state |
+| `full-refresh-pipeline.yml` | `workflow_dispatch` | Trigger a full refresh of an entire ingestion pipeline |
+| `full-refresh-tables.yml` | `workflow_dispatch` | Trigger a full refresh of specific tables within a pipeline |
+
+### Self-Hosted Runner Prerequisites
+
+All workflows use `runs-on: self-hosted`. The runner machine must have:
+
+- **Terraform** >= 1.10 available on `PATH`
+- **Python venv activated** — the workflows use `python` (not `python3`). Activate the project's Poetry-managed venv in the runner's startup shell so that `python`, `pip`, and all SDK dependencies resolve correctly:
+
+  ```bash
+  source /path/to/poetry/virtualenvs/lakeflow-connect-terraform-<hash>-py3.XX/bin/activate
+  ```
+
+  To find the venv path on your machine:
+  ```bash
+  poetry env list --full-path
+  ```
+
+### Required Repository Secrets
+
+Configure these under **Settings → Secrets and variables → Actions → Secrets**:
+
+| Secret | Description | Used by |
+|--------|-------------|---------|
+| `ARM_TENANT_ID` | Azure AD tenant ID — shared by both SPNs | All workflows |
+| `DATABRICKS_HOST` | Databricks workspace URL (e.g. `https://adb-xxx.azuredatabricks.net`) | All workflows |
+| `TF_STATE_ARM_CLIENT_ID` | Client ID of the **TF State SPN** — authenticates to Azure Blob backend | `terraform-deploy`, `terraform-release`, `terraform-output-pipeline-ids` |
+| `TF_STATE_ARM_CLIENT_SECRET` | Client secret of the TF State SPN | same as above |
+| `TF_STATE_ARM_SUBSCRIPTION_ID` | Azure subscription ID that contains the TF state storage account | same as above |
+| `DEPLOY_SPN_CLIENT_ID` | Client ID of the **Deploy SPN** — used by the Databricks Terraform provider and SDK | All workflows |
+| `DEPLOY_SPN_CLIENT_SECRET` | Client secret of the Deploy SPN | All workflows |
+
+> **Two-SPN model:** `TF_STATE_*` credentials authenticate only to Azure Blob Storage (Terraform state); they never touch Databricks. `DEPLOY_SPN_*` credentials are the Databricks-registered service principal used for `terraform plan/apply`, Databricks SDK calls, and reading Terraform state outputs — consistently across all workflows. No PAT tokens are used. See the [Terraform Backend section](#step-4-configure-terraform-backend) for the full explanation.
+
+### Required Repository Variables
+
+Configure these under **Settings → Secrets and variables → Actions → Variables**:
+
+| Variable | Description | Used by |
+|----------|-------------|---------|
+| `TF_STATE_RESOURCE_GROUP` | Azure Resource Group containing the TF state storage account | `terraform-deploy`, `terraform-release`, `terraform-output-pipeline-ids` |
+| `TF_STATE_STORAGE_ACCOUNT` | Azure Storage Account name | same as above |
+| `TF_STATE_CONTAINER` | Blob container name within the storage account | same as above |
+| `TF_STATE_KEY` | Blob path/filename for the `.tfstate` file (e.g. `lakeflow-connect/terraform.tfstate`) | same as above |
+
+### Optional: GitHub Environments for Approval Gates
+
+The deploy and refresh workflows support human approval gates via [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment). To enable them:
+
+1. Create an environment named **`production-deploy`** (for Terraform apply) and/or **`production-refresh`** (for pipeline refresh jobs) under **Settings → Environments**.
+2. Add required reviewers to each environment.
+3. Uncomment the `environment:` block in the relevant workflow job (search for `# environment:` in the workflow files).
+
+> Approval gates require **GitHub Pro, Team, or Enterprise** for private repositories.
+
 ## YAML Configuration
 
 See `config/examples/` for complete example configurations ([MySQL](config/examples/mysql.yml), [Oracle](config/examples/oracle.yml), [PostgreSQL](config/examples/postgresql.yml), [SQL Server](config/examples/sqlserver.yml)). The configuration is fully YAML-driven with the following main sections:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ lakeflow-connect-terraform/
 │       └── sqlserver.yml         # SQL Server example
 ├── infra/                       # Terraform root module
 │   ├── backend.tf
+│   ├── backend.local.tfvars.example  # Copy to backend.local.tfvars (non-secrets only; gitignored)
 │   ├── main.tf
 │   ├── locals.tf
 │   ├── outputs.tf
@@ -214,47 +215,116 @@ export DATABRICKS_CONFIG_PROFILE=production
 
 ### Step 4: Configure Terraform Backend
 
-**Option A: Local Backend (Default - For Single User)**
+Terraform stores [state](https://developer.hashicorp.com/terraform/language/state) in a **backend**. This repository ships with **`azurerm` (Azure Blob Storage)** as an **example** of a **remote** backend for teams and CI; you can swap it for any other [supported backend](https://developer.hashicorp.com/terraform/language/settings/backends) (Amazon S3, Google Cloud Storage, Terraform Cloud, etc.) by changing `infra/backend.tf` and following that backend’s init instructions.
 
-The project is configured with local backend by default. State is stored at `infra/terraform.tfstate`.
+**Who touches the state blob (remote `azurerm` example only)**
+
+State in Azure Storage is **not** opened using whatever you set in `ARM_CLIENT_ID` for deployment unless you deliberately use the **same** app registration for both roles.
+
+| Identity | Purpose | When it is used |
+|----------|---------|-----------------|
+| **TF state SPN** | **Only** Azure Blob access for the Terraform state file | Supplied at **`terraform init`** time—via **environment variables** (recommended) and/or `-backend-config` flags that reference them—**not** by committing secrets in a repo file. This principal **does not** deploy Databricks resources; it only needs access to the state container/blob. |
+| **Deploy SPN** | Databricks (and any Azure usage your root module expects via providers) | **`ARM_*` and `DATABRICKS_*` during `terraform plan` / `apply`**—this is a **different** service principal in the recommended setup. |
+
+**Recommended:** use **two** Azure AD applications (two client IDs): one for state, one for deploy.  
+**Alternative:** a single app registration can fill both roles; then you may reuse the same values in env vars for init and for `ARM_*` during plan/apply—still use an explicit init step (file + `-backend-config` for credentials from env) so it is obvious which identity touches the state blob.
+
+**Azure permissions for the TF state SPN (Blob backend with `use_azuread_auth=true`)**
+
+The Entra ID application whose **client ID** you pass at init (for example via `TF_STATE_ARM_CLIENT_ID` and the matching secret) must be able to read and write the state blob. At minimum, assign that principal **[Storage Blob Data Contributor](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor)** on the **Azure Storage blob container** that holds Terraform state (or on the parent **storage account** if you prefer a broader scope).
+
+Grant this principal **data-plane** access via Azure RBAC, not storage account keys:
+
+- **Minimum:** **Storage Blob Data Contributor** scoped to the state **container** is sufficient for typical state locking and read/write.
+- `use_azuread_auth=true` means Terraform authenticates to Blob Storage with Azure AD; the SPN must be able to read and write that blob.
+
+---
+
+#### Option A — Local backend (simple / single user)
+
+In `infra/backend.tf`, comment out `backend "azurerm" {}` and uncomment `backend "local" {}` (only one backend block may be active). Then:
 
 ```bash
 cd infra
-terraform init
-terraform validate
-```
-
-**Option B: Remote Backend (Recommended for Teams)**
-
-For team collaboration, use a remote backend like Azure Storage. Update `infra/backend.tf`:
-
-```hcl
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "terraform-state-rg"
-    storage_account_name = "tfstatelakeflow"
-    container_name       = "tfstate"
-    key                  = "lakeflow-connect.tfstate"
-  }
-}
-```
-
-Then initialize with the backend configuration:
-```bash
-cd infra
-
-# Set Azure credentials
-export ARM_SUBSCRIPTION_ID="<subscription_id>"
-export ARM_TENANT_ID="<tenant_id>"
-export ARM_CLIENT_ID="<client_id>"
-export ARM_CLIENT_SECRET="<client_secret>"
-
-# Initialize with remote backend
 terraform init -reconfigure
 terraform validate
 ```
 
-Other Remote Backend Options can be used. See [Terraform Backend Documentation](https://developer.hashicorp.com/terraform/language/settings/backends) for more options.
+State file path: `infra/terraform.tfstate`. Do not commit that file if you later move to shared remote state. No TF state SPN or Azure storage setup is required for this option.
+
+---
+
+#### Option B — Remote backend (example: Azure Storage / `azurerm`) - This is recommended, if one has access to a remote backend state store while developing.
+
+`infra/backend.tf` uses an **empty** `backend "azurerm" {}` block ([partial configuration](https://developer.hashicorp.com/terraform/language/settings/backends#partial-configuration)).  
+**Do not commit secrets:** keep storage **names** (and similar non-secrets) in a local file if you want; keep **TF state SPN** credentials in **environment variables** (or your CI/secret manager) and pass them into `terraform init` as shown below (same idea as the GitHub Actions workflows, which inject secrets as env-backed `terraform init` arguments).
+
+**Local / team: non-secret file + env vars for the TF state SPN**
+
+1. Copy the example and fill in **only** non-secret values (the copy is Git ignored by `*.tfvars`):
+
+   ```bash
+   cp infra/backend.local.tfvars.example infra/backend.local.tfvars
+   ```
+
+2. Edit `infra/backend.local.tfvars` with your storage account, container, and state blob **key**—**not** client IDs or secrets.
+
+3. Export the **TF state SPN** in your shell (names are suggestions; align with the `terraform init` command you use):
+
+   ```bash
+   export TF_STATE_ARM_CLIENT_ID="<tf_state_app_id>"
+   export TF_STATE_ARM_CLIENT_SECRET="<tf_state_secret>"
+   export TF_STATE_ARM_SUBSCRIPTION_ID="<subscription_for_state_blob>"
+   export TF_STATE_ARM_TENANT_ID="<tenant_id>"
+   ```
+
+   You can load these from a process manager, `direnv`, or a **gitignored** `.env` file (this repo already ignores `.env`) and never commits them.
+
+4. Initialize from `infra/` so credentials come from the environment (shell expands the variables; nothing secret is stored on disk in tracked files):
+
+   ```bash
+   cd infra
+   terraform init -reconfigure \
+     -backend-config=backend.local.tfvars \
+     -backend-config="client_id=${TF_STATE_ARM_CLIENT_ID}" \
+     -backend-config="client_secret=${TF_STATE_ARM_CLIENT_SECRET}" \
+     -backend-config="subscription_id=${TF_STATE_ARM_SUBSCRIPTION_ID}" \
+     -backend-config="tenant_id=${TF_STATE_ARM_TENANT_ID}"
+   terraform validate
+   ```
+
+5. For **plan/apply**, set environment variables for the **deploy** SPN and then run Terraform:  
+**Note:** - `DATABRICKS_CONFIG_PROFILE` env var is used below, however there are several other options to auth to Databricks. Refer to [Databricks Terraform provider Authentication documentation](https://registry.terraform.io/providers/databricks/databricks/latest/docs#authentication) for other options.
+
+   ```bash
+   export DATABRICKS_CONFIG_PROFILE=<Config profile of choice of Deploy SPN with access to Databricks assets>
+
+   poetry run terraform plan  --var yaml_config_path=../config/lakeflow_<env>.yml
+   poetry run terraform apply --var yaml_config_path=../config/lakeflow_<env>.yml
+   ```
+
+**Equivalent `terraform init` (CI or fully inline)**
+
+From `infra/`, you can pass the same non-secret keys as in `backend.local.tfvars` via repeated `-backend-config` flags (see `.github/workflows/terraform-deploy.yml` and `terraform-release.yml`). Supply **TF state** authentication the same way as locally: **secrets from environment variables** (CI: GitHub Actions secrets), not from committed files—for example:
+
+- `resource_group_name`, `storage_account_name`, `container_name`, `key`
+- `use_azuread_auth=true` (when using Azure AD / RBAC on the storage account)
+- `client_id`, `client_secret`, `subscription_id`, `tenant_id` for the **TF state** SPN via `-backend-config="..."` populated from your secret store or `${TF_STATE_ARM_*}` in a shell
+
+**GitHub Actions (this repo’s `azurerm` example)**
+
+Configure these **repository variables** (non-secret identifiers for the state blob):
+
+- `TF_STATE_RESOURCE_GROUP`
+- `TF_STATE_STORAGE_ACCOUNT`
+- `TF_STATE_CONTAINER`
+- `TF_STATE_KEY`
+
+Workflows pass them with `terraform init` alongside the TF state SPN **secrets** (`TF_STATE_ARM_*`, `ARM_TENANT_ID`). Plan/apply jobs set `ARM_*` to the **deploy** SPN.
+
+**Other remote backends**
+
+If you do not use Azure Blob, replace the backend block in `infra/backend.tf` with your chosen backend and follow HashiCorp’s documentation for that provider; the **deploy** SPN and YAML-driven Databricks resources stay the same—only state storage and `terraform init` differ.
 
 ### Step 5: Deploy Infrastructure
 

--- a/config/lakeflow_dev.yml
+++ b/config/lakeflow_dev.yml
@@ -1,11 +1,14 @@
 # Application name and Databricks environment name
 env: "dev"
-app_name: "wealth_mgmt"
+app_name: "oracle_test"
 
 # Provider the name of the Unity catalog connection
 connection:
-  name: "pgsql_aurora_amenon_connection_v1"
-  source_type: "POSTGRESQL"
+  name: "lf_connect_oracle19c"
+  source_type: "ORACLE"
+  # connection_parameters only applies when source_type is ORACLE (e.g. CDB name)
+  connection_parameters:
+    source_catalog: "ORCLCDB"
 
 # Unity Catalog configuration
 # global_uc_catalog: Default UC catalog where ingestion pipeline tables will land
@@ -19,63 +22,48 @@ unity_catalog:
 # The cluster policy used with the deployment of the gateway pipeline
 gateway_pipeline_cluster_policy_name: job_compute_for_spn_for_lf_connect
 
-# List of databases within the PostgreSQL to ingest from
-# The 'use_schema_ingestion' flag determines whether all tables in the schema are ingested automatically (true) 
+# List of databases within the Oracle to ingest from
+# The 'use_schema_ingestion' flag determines whether all tables in the schema are ingested automatically (true)
 # or only the explicitly listed tables are ingested (false). Setting it to 'true' will ignore the 'tables' list.
 databases:
-  - name: wealth_mgmt_one
+  - name: ORAPDB1
     # Optional: Override global_uc_catalog for this specific database
     # uc_catalog: "custom_catalog_name"  # If not provided, uses global_uc_catalog
-    
-    # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-    # Example: With prefix "wealth_mgmt_one_" → wealth_mgmt_one_client_management
-    # Example: With suffix "_raw" → client_management_raw
-    schema_prefix: "wealth_mgmt_one_"
-    # schema_suffix: "_raw"
-    
-    # For PostgreSQL: Replication slot and publication configuration (Public Preview feature)
-    # These should be pre-created in the source database
-    replication_slot: dbx_slot_wealth_mgmt_one
-    publication: dbx_pub_wealth_mgmt_one
-    schemas:
-      - name: client_management
-        use_schema_ingestion: false
-        tables:
-          - source_table: accounts
-          - source_table: advisors
-          - source_table: clients
-      - name: portfolio_management
-        use_schema_ingestion: false
-        tables:
-          - source_table: holdings
-          - source_table: portfolios
-          - source_table: transactions
-  - name: wealth_mgmt_two
-    # Optional: Override global_uc_catalog for this specific database
-    uc_catalog: "lf_connect_another"  # If not provided, uses global_uc_catalog
-    
-    # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-    schema_prefix: "wealth_mgmt_two_"
-    schema_suffix: "_v2"
-    
-    # For PostgreSQL: Replication slot and publication configuration (Public Preview feature)
-    # These should be pre-created in the source database
-    replication_slot: dbx_slot_wealth_mgmt_two
-    publication: dbx_pub_wealth_mgmt_two
-    schemas:
-      - name: client_management
-        use_schema_ingestion: false
-        tables:
-          - source_table: accounts
-          - source_table: advisors
-          - source_table: clients
-      - name: portfolio_management
-        use_schema_ingestion: false
-        tables:
-          - source_table: holdings
-          - source_table: portfolios
-          - source_table: transactions
 
+    # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
+    # Example: With prefix "orapdb1_" → orapdb1_client_management
+    # Example: With suffix "_raw" → client_management_raw
+    schema_prefix: "orapdb1_"
+    # schema_suffix: "_raw"
+
+    schemas:
+      - name: CLIENT_MANAGEMENT
+        use_schema_ingestion: false
+        tables:
+          # - source_table: CLIENTS
+          - source_table: ACCOUNTS
+          - source_table: ADVISORS
+  # - name: ORAPDB2
+  #   # Optional: Override global_uc_catalog for this specific database
+  #   uc_catalog: "lf_connect_another"  # If not provided, uses global_uc_catalog
+  #
+  #   # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
+  #   schema_prefix: "orapdb2_"
+  #   schema_suffix: "_v2"
+  #
+  #   schemas:
+  #     - name: CLIENT_MANAGEMENT
+  #       use_schema_ingestion: false
+  #       tables:
+  #         - source_table: CLIENTS
+  #         - source_table: ACCOUNTS
+  #         - source_table: ADVISORS
+  #     - name: PORTFOLIO_MANAGEMENT
+  #       use_schema_ingestion: false
+  #       tables:
+  #         - source_table: HOLDINGS
+  #         - source_table: PORTFOLIOS
+  #         - source_table: TRANSACTIONS
 
 # Create one gateway pipeline for the entire application
 gateway_pipeline_cluster_config:
@@ -110,18 +98,18 @@ job:
   common_schedule:
     quartz_cron_expression: "0 */30 * * * ?"  # This schedule applies if 'common_job_for_all_pipelines' is 'true'
     timezone_id: "UTC"
-  
+
   # Per-database schedules apply when common_job_for_all_pipelines is false
   # Each schedule group can apply to one or more databases
   # Multiple databases can share the same schedule by listing them in 'applies_to'
   per_database_schedules:
     - name: "frequent_sync"
-      applies_to: ["wealth_mgmt_one"]
+      applies_to: ["ORAPDB1"]
       schedule:
         quartz_cron_expression: "0 */15 * * * ?"  # Run every 15 minutes
         timezone_id: "UTC"
     - name: "hourly_sync"
-      applies_to: ["wealth_mgmt_two"]
+      applies_to: []  # Add "ORAPDB2" when uncommenting second database above
       schedule:
         quartz_cron_expression: "0 0 * * * ?"  # Run every hour
         timezone_id: "UTC"

--- a/infra/backend.local.tfvars.example
+++ b/infra/backend.local.tfvars.example
@@ -1,0 +1,37 @@
+# Example partial backend configuration for `terraform init`.
+#
+# SECURITY: Keep this file to NON-SECRET values only (storage account names, blob
+# key path, flags). Do NOT put client_id, client_secret, or subscription IDs
+# here—those belong in environment variables so they are never committed.
+#
+# 1. Copy to `backend.local.tfvars` (gitignored via *.tfvars) and set the values below.
+# 2. Export the TF state SPN credentials in your shell (or load them from a secret
+#    store / CI — never check them into git). Recommended variable names:
+#      TF_STATE_ARM_CLIENT_ID
+#      TF_STATE_ARM_CLIENT_SECRET
+#      TF_STATE_ARM_SUBSCRIPTION_ID
+#      TF_STATE_ARM_TENANT_ID
+# 3. From `infra/`, run `terraform init` with the file PLUS explicit -backend-config
+#    flags that reference those variables (shell expands them — secrets stay out of files):
+#
+#      terraform init -reconfigure \
+#        -backend-config=backend.local.tfvars \
+#        -backend-config="client_id=${TF_STATE_ARM_CLIENT_ID}" \
+#        -backend-config="client_secret=${TF_STATE_ARM_CLIENT_SECRET}" \
+#        -backend-config="subscription_id=${TF_STATE_ARM_SUBSCRIPTION_ID}" \
+#        -backend-config="tenant_id=${TF_STATE_ARM_TENANT_ID}"
+#
+#    The azurerm backend also reads standard ARM_* variables if you prefer: you can
+#    temporarily export ARM_CLIENT_ID (etc.) to the TF state SPN, run init with only
+#    -backend-config=backend.local.tfvars, then replace ARM_* with the deploy SPN
+#    before plan/apply. Using TF_STATE_ARM_* + explicit -backend-config avoids mixing
+#    identities by mistake.
+#
+# 4. For plan/apply, set ARM_* / DATABRICKS_* to the deploy SPN (see README).
+
+# --- Azure Storage (state blob location — non-secret identifiers only) ---
+resource_group_name  = "<change_here>"
+storage_account_name = "<change_here>"
+container_name       = "<change_here>"
+key                  = "<change_here>"
+use_azuread_auth     = true

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,16 +1,14 @@
 terraform {
-  # Using local backend for state storage
-  # State file will be stored locally at: infra/terraform.tfstate
-  
-  # For team collaboration, replace with a remote backend:
-  # Example:
-  # backend "azurerm" {
-  #   resource_group_name  = "terraform-state-rg"
-  #   storage_account_name = "tfstatelakeflow"
-  #   container_name       = "tfstate"
-  #   key                  = "lakeflow-connect.tfstate"
-  # }
-  # Then run: terraform init -reconfigure
-  
+  # Uncomment below line for using local backend for state storage in local deployments . The state file will be stored locally at: infra/terraform.tfstate
   backend "local" {}
+  
+  # For CI/CD deployments in production or for team collaboration, use remote backend
+  #backend "azurerm" {
+  #  resource_group_name  = "ps-west-europe"
+  #  storage_account_name = "pswesteuropestorage"
+  #  container_name       = "tf-state"
+  #  key                  = "lakeflow-connect-cicd-full-refresh-demo.tfstate"
+  #  use_azuread_auth     = true
+  #}
+  
 }

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,14 +1,19 @@
 terraform {
-  # Uncomment below line for using local backend for state storage in local deployments . The state file will be stored locally at: infra/terraform.tfstate
-  backend "local" {}
-  
-  # For CI/CD deployments in production or for team collaboration, use remote backend
-  #backend "azurerm" {
-  #  resource_group_name  = "ps-west-europe"
-  #  storage_account_name = "pswesteuropestorage"
-  #  container_name       = "tf-state"
-  #  key                  = "lakeflow-connect-cicd-full-refresh-demo.tfstate"
-  #  use_azuread_auth     = true
-  #}
-  
+  # ---------------------------------------------------------------------------
+  # Backends: enable exactly ONE of the blocks below (uncomment one, comment the
+  # other). Terraform allows only a single backend block per configuration.
+  # ---------------------------------------------------------------------------
+
+  # Option A — Remote state (Recommended for teams / CI. Suitable for Production)
+  #   `azurerm` shown as example. Adapt to other remote backends as needed.
+  #   Intentionally set as Partial / "empty" backend
+  #   During `terraform init` pass along settings ( see README for more details)
+
+  backend "azurerm" {}
+
+  # Option B — Local filesystem state (legacy / single-user option for local state)
+  #   Uncomment `backend "local" {}` below, comment out `backend "azurerm" {}`,
+  #   then `terraform init`. State file path: infra/terraform.tfstate (relative to the working directory)
+
+  # backend "local" {}
 }

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,3 +1,17 @@
 provider "databricks" {
-  # During development using `DATABRICKS_HOST` and `DATABRICKS_AUTH_TYPE` (set value to `azure-cli`) environment variables
+  # Authentication is configured entirely via environment variables.
+  #
+  # Local development (azure-cli):
+  #   `DATABRICKS_HOST      = workspace URL` and `DATABRICKS_AUTH_TYPE = azure-cli`
+  #   or 
+  #   `DATABRICKS_CONFIG_PROFILE` if preferred
+  #
+  # CI/CD (service principal via Entra ID azure-client-secret):
+  #   DATABRICKS_HOST                = workspace URL
+  #   DATABRICKS_AZURE_CLIENT_ID     = DEPLOY_SPN Entra ID application (client) ID
+  #   DATABRICKS_AZURE_CLIENT_SECRET = DEPLOY_SPN Entra ID client secret
+  #   DATABRICKS_AZURE_TENANT_ID     = Azure AD tenant ID
+  #
+  # In CI/CD, these env vars are set in the shell after unsetting ARM_*
+  # (which are used by the azurerm backend for terraform state).
 }

--- a/tools/trigger_full_refresh.py
+++ b/tools/trigger_full_refresh.py
@@ -18,7 +18,8 @@ Usage:
 
 Requires:
   - DATABRICKS_HOST: Databricks workspace URL
-  - DATABRICKS_TOKEN: Databricks personal access token (or service principal token)
+  - ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID: Azure service principal credentials
+    (the Databricks SDK picks these up automatically for azure-client-secret auth)
 """
 
 import argparse

--- a/tools/trigger_full_refresh.py
+++ b/tools/trigger_full_refresh.py
@@ -1,0 +1,325 @@
+"""
+Trigger full refresh on Databricks Lakeflow Connect ingestion pipelines.
+
+Supports two modes:
+  1. Full pipeline refresh  - refreshes ALL tables in a pipeline
+  2. Selective table refresh - refreshes only specified tables in a pipeline
+
+Usage:
+  # Full pipeline refresh
+  python tools/trigger_full_refresh.py --pipeline-id <id> --mode full
+
+  # Selective table refresh (specific tables)
+  python tools/trigger_full_refresh.py --pipeline-id <id> --mode tables \
+      --tables "catalog.schema.table1,catalog.schema.table2"
+
+  # Dry run (validate inputs without triggering refresh)
+  python tools/trigger_full_refresh.py --pipeline-id <id> --mode full --dry-run
+
+Requires:
+  - DATABRICKS_HOST: Databricks workspace URL
+  - DATABRICKS_TOKEN: Databricks personal access token (or service principal token)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+try:
+    from databricks.sdk import WorkspaceClient
+except ImportError:
+    print("ERROR: databricks-sdk is required. Install with: pip install databricks-sdk")
+    sys.exit(1)
+
+
+def get_pipeline_info(client: WorkspaceClient, pipeline_id: str) -> dict:
+    """Retrieve pipeline metadata for validation and display."""
+    pipeline = client.pipelines.get(pipeline_id=pipeline_id)
+    return {
+        "pipeline_id": pipeline.pipeline_id,
+        "name": pipeline.name,
+        "state": pipeline.state.value if pipeline.state else "UNKNOWN",
+    }
+
+
+def resolve_table_names(client: WorkspaceClient, pipeline_id: str, tables: list[str]) -> list[str]:
+    """
+    Resolve user-supplied table names to the EXACT names used in the pipeline's
+    ingestion_definition (required by full_refresh_selection — case-sensitive).
+
+    Accepts schema.table or catalog.schema.table (matched case-insensitively
+    against the pipeline spec; the pipeline's own casing is always used in output).
+    """
+    pipeline = client.pipelines.get(pipeline_id=pipeline_id)
+
+    # Build a map: lowercase(catalog.schema.table) -> exact(catalog.schema.table)
+    # from the pipeline's ingestion_definition.objects
+    pipeline_tables: dict[str, str] = {}
+    if (pipeline.spec
+            and pipeline.spec.ingestion_definition
+            and pipeline.spec.ingestion_definition.objects):
+        for obj in pipeline.spec.ingestion_definition.objects:
+            if obj.table:
+                t = obj.table
+                exact = f"{t.destination_catalog}.{t.destination_schema}.{t.destination_table}"
+                pipeline_tables[exact.lower()] = exact
+
+    if not pipeline_tables:
+        print("ERROR: Pipeline has no ingestion tables defined in its spec.")
+        sys.exit(1)
+
+    print(f"Pipeline tables: {list(pipeline_tables.values())}")
+
+    resolved = []
+    for table in tables:
+        parts = table.strip().split(".")
+        if len(parts) == 2:
+            # Match schema.table case-insensitively against the last two parts
+            schema_table = table.strip().lower()
+            matched = next(
+                (exact for lc, exact in pipeline_tables.items()
+                 if ".".join(lc.split(".")[1:]) == schema_table),
+                None,
+            )
+        elif len(parts) == 3:
+            matched = pipeline_tables.get(table.strip().lower())
+        else:
+            print(f"ERROR: Table '{table}' must be schema.table or catalog.schema.table")
+            sys.exit(1)
+
+        if matched is None:
+            print(f"ERROR: Table '{table}' not found in pipeline ingestion definition.")
+            print(f"  Available: {list(pipeline_tables.values())}")
+            sys.exit(1)
+
+        resolved.append(matched)
+
+    return resolved
+
+
+def trigger_full_refresh(
+    client: WorkspaceClient,
+    pipeline_id: str,
+    mode: str,
+    tables: list[str] | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Trigger a full refresh on a Databricks pipeline.
+
+    Args:
+        client: Databricks WorkspaceClient
+        pipeline_id: The pipeline ID to refresh
+        mode: 'full' for entire pipeline, 'tables' for specific tables
+        tables: List of fully-qualified table names (required when mode='tables')
+        dry_run: If True, validate inputs but do not trigger the refresh
+
+    Returns:
+        dict with update_id and status
+    """
+    # Validate pipeline exists and is in a refreshable state
+    info = get_pipeline_info(client, pipeline_id)
+    print(f"Pipeline: {info['name']} ({info['pipeline_id']})")
+    print(f"Current state: {info['state']}")
+
+    if dry_run:
+        print("\n[DRY RUN] Would trigger the following refresh:")
+        print(f"  Mode: {mode}")
+        if mode == "tables" and tables:
+            print(f"  Tables: {', '.join(tables)}")
+        print("\n[DRY RUN] No changes made.")
+        return {"status": "dry_run", "pipeline_id": pipeline_id}
+
+    if mode == "full":
+        print("\nTriggering FULL REFRESH on entire pipeline...")
+        update = client.pipelines.start_update(
+            pipeline_id=pipeline_id,
+            full_refresh=True,
+        )
+    elif mode == "tables":
+        if not tables:
+            print("ERROR: --tables is required when mode is 'tables'")
+            sys.exit(1)
+        print(f"\nTriggering FULL REFRESH on specific tables:")
+        for t in tables:
+            print(f"  - {t}")
+        update = client.pipelines.start_update(
+            pipeline_id=pipeline_id,
+            full_refresh_selection=tables,
+        )
+    else:
+        print(f"ERROR: Unknown mode '{mode}'. Use 'full' or 'tables'.")
+        sys.exit(1)
+
+    update_id = update.update_id
+    print(f"\nUpdate triggered successfully!")
+    print(f"Update ID: {update_id}")
+
+    return {
+        "status": "triggered",
+        "pipeline_id": pipeline_id,
+        "update_id": update_id,
+        "mode": mode,
+        "tables": tables if mode == "tables" else "ALL",
+    }
+
+
+def wait_for_completion(
+    client: WorkspaceClient,
+    pipeline_id: str,
+    update_id: str,
+    timeout_minutes: int = 60,
+    check_interval_seconds: int = 30,
+) -> str:
+    """
+    Wait for a pipeline update to complete.
+
+    Returns the final state: COMPLETED, FAILED, CANCELED, etc.
+    """
+    print(f"\nWaiting for update {update_id} to complete (timeout: {timeout_minutes}m)...")
+    start_time = time.time()
+    timeout_seconds = timeout_minutes * 60
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > timeout_seconds:
+            print(f"ERROR: Timeout after {timeout_minutes} minutes")
+            return "TIMEOUT"
+
+        update_info = client.pipelines.get_update(
+            pipeline_id=pipeline_id,
+            update_id=update_id,
+        )
+        state = update_info.update.state.value if update_info.update.state else "UNKNOWN"
+        print(f"  [{int(elapsed)}s] State: {state}")
+
+        if state in ("COMPLETED", "FAILED", "CANCELED"):
+            return state
+
+        time.sleep(check_interval_seconds)
+
+
+def resolve_pipeline_ids_from_config(config_path: str, target: str) -> list[str]:
+    """
+    Resolve pipeline pair keys from the YAML config file.
+
+    The target can be:
+      - A database name (e.g., 'wealth_mgmt_one') -> returns all schema pairs
+      - A database.schema pair (e.g., 'wealth_mgmt_one.client_management')
+
+    Note: This returns pair_keys, not pipeline IDs. The caller must map these
+    to actual pipeline IDs using Terraform output or state.
+    """
+    import yaml
+
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    pair_keys = []
+    for db in cfg.get("databases", []):
+        for schema in db.get("schemas", []):
+            pair_key = f"{db['name']}_{schema['name']}"
+            if target == db["name"] or target == f"{db['name']}.{schema['name']}":
+                pair_keys.append(pair_key)
+
+    if not pair_keys:
+        print(f"WARNING: No matching pipelines found for target '{target}'")
+
+    return pair_keys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Trigger full refresh on Databricks Lakeflow Connect pipelines"
+    )
+    parser.add_argument(
+        "--pipeline-id",
+        required=True,
+        help="Databricks pipeline ID to refresh",
+    )
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=["full", "tables"],
+        help="Refresh mode: 'full' for entire pipeline, 'tables' for specific tables",
+    )
+    parser.add_argument(
+        "--tables",
+        help="Comma-separated list of fully-qualified table names (catalog.schema.table)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs without triggering the refresh",
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for the refresh to complete",
+    )
+    parser.add_argument(
+        "--timeout-minutes",
+        type=int,
+        default=60,
+        help="Timeout in minutes when --wait is used (default: 60)",
+    )
+    parser.add_argument(
+        "--check-interval",
+        type=int,
+        default=30,
+        help="Check interval in seconds when --wait is used (default: 30)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate environment
+    if not os.environ.get("DATABRICKS_HOST"):
+        print("ERROR: DATABRICKS_HOST environment variable is required")
+        sys.exit(1)
+
+    # Initialize client
+    client = WorkspaceClient()
+
+    # Parse and resolve tables if provided
+    tables = None
+    if args.tables:
+        tables = resolve_table_names(client, args.pipeline_id, args.tables.split(","))
+
+    if args.mode == "tables" and not tables:
+        print("ERROR: --tables is required when --mode is 'tables'")
+        sys.exit(1)
+
+    # Trigger the refresh
+    result = trigger_full_refresh(
+        client=client,
+        pipeline_id=args.pipeline_id,
+        mode=args.mode,
+        tables=tables,
+        dry_run=args.dry_run,
+    )
+
+    if args.dry_run:
+        sys.exit(0)
+
+    # Optionally wait for completion
+    if args.wait and result.get("update_id"):
+        final_state = wait_for_completion(
+            client=client,
+            pipeline_id=args.pipeline_id,
+            update_id=result["update_id"],
+            timeout_minutes=args.timeout_minutes,
+            check_interval_seconds=args.check_interval,
+        )
+        print(f"\nFinal state: {final_state}")
+        if final_state != "COMPLETED":
+            sys.exit(1)
+
+    # Output result as JSON for CI/CD consumption
+    print(f"\n--- Result ---")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  ## Summary
  - Introduce GitHub workflows for CI/CD
  - Replace all `python3` references with `python` across all 5 GitHub Actions                     
    workflows — aligns with the self-hosted runner's activated Poetry venv (Python 3.14)
  - Remove `DATABRICKS_TOKEN` PAT auth entirely; replace with consistent Deploy SPN                
    (`ARM_CLIENT_ID / ARM_CLIENT_SECRET / ARM_TENANT_ID`) in                                       
    `terraform-output-pipeline-ids.yml` and fix matching stale comments in                         
    `full-refresh-pipeline.yml` and `tools/trigger_full_refresh.py`                                
  - Add **GitHub Actions CI/CD Setup** section to README covering:                                 
    - Workflows overview table                                                                     
    - Self-hosted runner prerequisites (venv activation)
    - Required secrets and variables reference tables                                              
    - Optional approval gate setup instructions                                                    
 