### PR TITLE
chore(ci): run terraform plan on PRs instead of push to main

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -41,8 +41,8 @@
 name: "Terraform Deploy - Lakeflow Connect"
 
 on:
-  # Auto-run plan on push to main (when infra or config changes)
-  push:
+  # Run validate + plan on PRs targeting main (when infra or config changes)
+  pull_request:
     branches: [main]
     paths:
       - "infra/**"


### PR DESCRIPTION
Shifts the validate+plan check left; `terraform plan` now runs on PRs targeting main so reviewers see infrastructure changes before merge, not after. 
Apply and destroy remain manual via workflow_dispatch only.