### PR TITLE
feat(config): add gateway validation toggle

### DIFF
--- a/config/examples/mysql.yml
+++ b/config/examples/mysql.yml
@@ -70,7 +70,10 @@ gateway_pipeline_cluster_config:
   spark_env_vars: {}
   ssh_public_keys: []
 
+# Set 'enabled: false' to skip validation — useful when pipelines are already running
+# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
+  enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 

--- a/config/examples/oracle.yml
+++ b/config/examples/oracle.yml
@@ -81,7 +81,10 @@ gateway_pipeline_cluster_config:
   ssh_public_keys: []
 
 # Gateway validation configuration : This configuration is used by a script to validate that the gateway pipeline is running before the job resource is created/updated.
+# Set 'enabled: false' to skip validation — useful when pipelines are already running
+# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
+  enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 

--- a/config/examples/postgresql.yml
+++ b/config/examples/postgresql.yml
@@ -93,7 +93,10 @@ gateway_pipeline_cluster_config:
   ssh_public_keys: []
 
 # Gateway validation configuration : This configuration is used by a script to validate that the gateway pipeline is running before the job resource is created/updated.
+# Set 'enabled: false' to skip validation — useful when pipelines are already running
+# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
+  enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 

--- a/config/examples/sqlserver.yml
+++ b/config/examples/sqlserver.yml
@@ -104,7 +104,10 @@ gateway_pipeline_cluster_config:
   ssh_public_keys: []
 
 # Gateway validation configuration : This configuration is used by a script to validate that the gateway pipeline is running before the job resource is created/updated.
+# Set 'enabled: false' to skip validation — useful when pipelines are already running
+# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
+  enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 

--- a/config/lakeflow_dev.yml
+++ b/config/lakeflow_dev.yml
@@ -81,7 +81,10 @@ gateway_pipeline_cluster_config:
   ssh_public_keys: []
 
 # Gateway validation configuration : This configuration is used by a script to validate that the gateway pipeline is running before the job resource is created/updated.
+# Set 'enabled: false' to skip validation entirely — useful when pipelines are already running
+# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
+  enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -138,8 +138,16 @@ gateway_pipeline_cluster_policy_name: my_cluster_policy
 
 ```yaml
 gateway_validation:
+  enabled: true                # Set to false to skip validation entirely
   timeout_minutes: 30
   check_interval_seconds: 15
 ```
 
 After the gateway pipeline is created or updated, a validation script polls the pipeline status before downstream ingestion pipeline resources are created or updated. These settings control how long to wait and how frequently to poll.
+
+- `enabled`: When `true` (default), validation runs and orchestration jobs are not created or updated until the gateway is confirmed running. Set to `false` to skip this step; orchestration jobs deployment proceed immediately after the gateway and ingestion pipeline resources are applied. Useful when pipelines are already actively running and a validate-only pipeline run triggered by Terraform would conflict with ongoing ingestion.
+
+  > **Note:** On first-ever deployment with `enabled: false`, there is a risk that ingestion jobs fire before the gateway is fully up, depending on how soon the job schedule triggers. The first run may fail, but subsequent runs should succeed once the gateway is running normally.
+
+- `timeout_minutes`: How long to wait for the gateway to reach a running state before failing (minimum 15).
+- `check_interval_seconds`: How frequently to poll the pipeline status (minimum 5).

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -11,6 +11,9 @@ locals {
   # MySQL has no schema level (database = schema). Used to set source_catalog/source_schema and table naming.
   is_mysql = try(local.connection.source_type, "") == "MYSQL"
 
+  # Gateway validation toggle - defaults to true if not specified (preserves existing behaviour)
+  gateway_validation_enabled = try(local.cfg.gateway_validation.enabled, true)
+
   # Event log configuration - defaults to true if not specified
   event_log_to_table = try(local.cfg.event_log.to_table, true)
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -54,13 +54,16 @@ module "ingestion" {
   depends_on = [module.gateway, module.landing_catalog_validation]
 }
 
-# Validate that the gateway pipeline is running before proceeding to orchestrator
+# Validate that the gateway pipeline is running before proceeding to orchestrator.
+# Set gateway_validation.enabled: false in the YAML config to skip this step
+# (useful when pipelines are already running and a validate-only run would fail).
 module "gateway_validation" {
   source = "./modules/gateway_validation"
+  count  = local.gateway_validation_enabled ? 1 : 0
 
   pipeline_id            = module.gateway.pipeline_id
-  timeout_minutes        = local.cfg.gateway_validation.timeout_minutes
-  check_interval_seconds = local.cfg.gateway_validation.check_interval_seconds
+  timeout_minutes        = try(local.cfg.gateway_validation.timeout_minutes, 30)
+  check_interval_seconds = try(local.cfg.gateway_validation.check_interval_seconds, 15)
   yaml_config_path       = var.yaml_config_path
   ingestion_pipeline_ids = [for k, v in module.ingestion : v.pipeline_id]
 

--- a/tools/pydantic_validator.py
+++ b/tools/pydantic_validator.py
@@ -389,9 +389,13 @@ class GatewayPipelineClusterConfig(BaseModel):
 
 class GatewayValidationConfig(BaseModel):
     """Gateway validation configuration."""
-    
-    timeout_minutes: int = Field(..., ge=15)
-    check_interval_seconds: int = Field(..., ge=5)
+
+    enabled: bool = Field(
+        default=True,
+        description="Set to false to skip gateway validation entirely (e.g. when pipelines are already running)"
+    )
+    timeout_minutes: int = Field(default=30, ge=15)
+    check_interval_seconds: int = Field(default=15, ge=5)
 
 
 class EventLogConfig(BaseModel):


### PR DESCRIPTION
Introduces gateway_validation.enabled flag (default: true) so teams can skip the validate-only gateway run when pipelines are already actively running. When false, orchestration jobs proceed immediately after gateway and ingestion pipeline resources are applied.

- infra/locals.tf: read enabled flag with safe try() default
- infra/main.tf: count-gate the gateway_validation module; wrap timeout/interval with try() so enabled: false works without them
- tools/pydantic_validator.py: add enabled field, make timeout and interval optional with defaults
- config/lakeflow_dev.yml + all four examples: add enabled: true with explanatory comment
- docs/yaml-configuration.md: document the flag and first-deploy risk
