### PR TITLE
feat(qbc): add Query-Based Connector support

### DIFF
--- a/config/examples/postgresql_qbc.yml
+++ b/config/examples/postgresql_qbc.yml
@@ -1,0 +1,79 @@
+# Query-Based Connector (QBC) example — PostgreSQL
+#
+# Use connector_type: QBC when you want Databricks to issue SQL queries
+# for incremental sync instead of streaming CDC events via a gateway pipeline.
+# QBC uses serverless compute; no gateway pipeline or cluster config is required.
+
+env: "dev"
+app_name: "wealth_mgmt_qbc"
+
+connector_type: QBC
+
+# UC connection name for the source database (must already exist in Unity Catalog)
+connection:
+  name: "amenon_qbc_lf_connect_postgresql"
+  source_type: "POSTGRESQL"
+  # Note: replication_slot and publication are NOT needed for QBC —
+  # QBC connects via the Unity Catalog connection, not the CDC replication path.
+
+
+# To use a single shared catalog instead, add the following block (Omit if using per-database uc_catalog overrides)
+#   unity_catalog:
+#     global_uc_catalog: "my_catalog"
+
+# QBC defaults — applied to all tables unless overridden per-table
+qbc:
+  default_cursor_column: "updated_at"   # Column used for incremental reads
+  default_scd_type: "SCD_TYPE_1"        # SCD_TYPE_1, SCD_TYPE_2, or APPEND_ONLY
+
+# Databases and tables to ingest.
+# QBC requires use_schema_ingestion: false — tables must be listed explicitly.
+# Each database overrides uc_catalog so its tables land in a dedicated catalog.
+databases:
+  - name: wealth_mgmt_one
+    uc_catalog: "lf_connect_qbc_wealth_mgmt_one"   # per-database catalog override
+    schemas:
+      - name: client_management
+        use_schema_ingestion: false
+        tables:
+          - source_table: accounts       # inherits default_cursor_column (updated_at) and default_scd_type
+          - source_table: advisors
+          - source_table: clients
+            scd_type: "SCD_TYPE_2"       # track full client history; cursor stays updated_at
+      - name: portfolio_management
+        use_schema_ingestion: false
+        tables:
+          - source_table: holdings
+          - source_table: portfolios
+          - source_table: transactions
+            cursor_column: "transaction_date"  # transactions has no updated_at column
+            scd_type: "APPEND_ONLY"            # transactions are immutable — append only
+            # Optional: mark logically deleted rows
+            # deletion_condition: "status = 'cancelled'"
+
+  - name: wealth_mgmt_two
+    uc_catalog: "lf_connect_qbc_wealth_mgmt_two"   # per-database catalog override
+    schemas:
+      - name: client_management
+        use_schema_ingestion: false
+        tables:
+          - source_table: accounts
+          - source_table: clients
+      - name: portfolio_management
+        use_schema_ingestion: false
+        tables:
+          - source_table: holdings
+          - source_table: transactions
+            cursor_column: "transaction_date"  # transactions has no updated_at column
+            scd_type: "APPEND_ONLY"
+
+# Event log configuration
+event_log:
+  to_table: true
+
+# Job orchestration — QBC always uses the common schedule
+job:
+  common_job_for_all_pipelines: true
+  common_schedule:
+    quartz_cron_expression: "0 0 * * * ?"   # Run every hour
+    timezone_id: "UTC"

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -1,6 +1,17 @@
 # YAML Configuration Reference
 
-See `config/examples/` for complete example configurations ([MySQL](../config/examples/mysql.yml), [Oracle](../config/examples/oracle.yml), [PostgreSQL](../config/examples/postgresql.yml), [SQL Server](../config/examples/sqlserver.yml)). The configuration is fully YAML-driven with the following main sections:
+See `config/examples/` for complete example configurations ([MySQL](../config/examples/mysql.yml), [Oracle](../config/examples/oracle.yml), [PostgreSQL CDC](../config/examples/postgresql.yml), [PostgreSQL QBC](../config/examples/postgresql_qbc.yml), [SQL Server](../config/examples/sqlserver.yml)). The configuration is fully YAML-driven with the following main sections:
+
+## Connector Type
+
+```yaml
+connector_type: CDC   # CDC (default) or QBC
+```
+
+Two connector modes are supported:
+
+- **CDC** (Change Data Capture, default): streams database changes in near-real-time via a gateway pipeline. Requires `gateway_pipeline_cluster_config` and — for PostgreSQL — a replication slot and publication per database.
+- **QBC** (Query-Based Connector): polls the source using SQL queries for incremental sync. Uses serverless compute; no gateway pipeline or cluster configuration needed. Requires explicit table lists with a `cursor_column` per table.
 
 ## Connection
 
@@ -68,6 +79,55 @@ databases:
 ### MySQL note
 
 MySQL has no schema level (the hierarchy is server → database → tables). In the YAML, list each database and under `schemas` use a placeholder name (e.g. `"<not applicable in MySQL>"`) and list tables by their full MySQL table name. Set `connection.source_type: "MYSQL"`. If `use_schema_ingestion: true` is set, it is ignored for MySQL and ingestion uses the `tables` list; the Pydantic validator prints an informational message when this is encountered. See `config/examples/mysql.yml` for a complete example.
+
+## QBC — Query-Based Connector
+
+When `connector_type: QBC`, replace the CDC-specific sections (`gateway_pipeline_cluster_config`, `gateway_validation`) with the optional `qbc` defaults block:
+
+```yaml
+connector_type: QBC
+
+qbc:
+  default_cursor_column: "updated_at"   # Column used for incremental reads (required unless set per-table)
+  default_scd_type: "SCD_TYPE_1"        # SCD_TYPE_1, SCD_TYPE_2, or APPEND_ONLY (default: SCD_TYPE_1)
+```
+
+Tables must be listed explicitly (`use_schema_ingestion: false`). Each table inherits the QBC defaults but can override them:
+
+```yaml
+databases:
+  - name: my_database
+    schemas:
+      - name: my_schema
+        use_schema_ingestion: false   # required for QBC
+        tables:
+          - source_table: orders          # uses default_cursor_column and default_scd_type
+          - source_table: customers
+            cursor_column: "modified_ts"  # per-table cursor override
+            scd_type: "SCD_TYPE_2"        # per-table SCD override
+          - source_table: events
+            scd_type: "APPEND_ONLY"
+            deletion_condition: "is_deleted = true"   # optional: marks logically deleted rows
+```
+
+QBC fields:
+
+| Field | Scope | Required | Description |
+|-------|-------|----------|-------------|
+| `qbc.default_cursor_column` | global | if not set per-table | Column used for incremental reads (e.g. `updated_at`) |
+| `qbc.default_scd_type` | global | no (default: `SCD_TYPE_1`) | Default SCD merge strategy |
+| `tables[].cursor_column` | per-table | if no global default | Overrides `default_cursor_column` for this table |
+| `tables[].scd_type` | per-table | no | Overrides `default_scd_type` for this table |
+| `tables[].deletion_condition` | per-table | no | SQL expression identifying soft-deleted rows |
+
+**SCD type reference:**
+- `SCD_TYPE_1`: Upsert — overwrite existing rows in place (default)
+- `SCD_TYPE_2`: Track full row history with effective-date columns
+- `APPEND_ONLY`: Insert every incoming row without deduplication or merging
+
+**PostgreSQL note for QBC:** `replication_slot` and `publication` are **not** needed — QBC connects via the Unity Catalog connection, not the CDC replication path.
+
+See `config/examples/postgresql_qbc.yml` for a complete example.
 
 ## Event Logs
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -2,16 +2,16 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/databricks/databricks" {
-  version     = "1.104.0"
+  version     = "1.113.0"
   constraints = ">= 1.104.0"
   hashes = [
-    "h1:46RauhPzx3/tTNAm240NHYSzOOoLcwQkv3YWumGT70I=",
-    "zh:1017be8c3f40ab895e54e4e20aff28b38ff0bb14e31f303a26b7e36f50693f68",
-    "zh:34cec3190716a53d67b794824ebff5da5d6928c2cea5442b7848c35a636ffa83",
-    "zh:60efb88f8789afff28fc0dbe59c8ea09871a99cd0e748bb3dc543d6c71ca150d",
-    "zh:66a20ab10f751268813cede9fab5bdd2a8be1b43ea8ab0882fef9c2383b30c98",
-    "zh:bfef69d0137e9c295be3169f1dc7a08047499c1094b6487e8f219bc18ae93ef8",
-    "zh:faccac9fbb7a39073c155f82f098ef3612cdf7efe322cc97c538cc6c702470d4",
+    "h1:gjhxtc1Vn5dWCtzlWQEWFuxppnLG3HhI0GPY7SS0g3g=",
+    "zh:2918db0e79f6e59efd8008cbc7c9d0634f67cbf4cd4a1ef59ba2ecbe0d4bbf42",
+    "zh:4f5caaf7bea4c435ae97c28c45086c213e182b67d1fe9b13f4e91b9e0b6ad7be",
+    "zh:69693b0bcbab3a184deb2744e8b90d5a9d1f7e19cdc414bc54a87280e37d65a9",
+    "zh:97dbbf0310299b1a74068f5fd1aad38447fb5a3d62c7f1ef521837523d7c3d78",
+    "zh:9aca39cd411b5059480db8c91e59badd7fb3027098377a0a398c6cdf2e40d6e8",
+    "zh:a9dd056cdc012e74268a8fb3738f66d6eb2004c364c09ef131e6ba2803b01a87",
   ]
 }
 

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -11,11 +11,39 @@ locals {
   # MySQL has no schema level (database = schema). Used to set source_catalog/source_schema and table naming.
   is_mysql = try(local.connection.source_type, "") == "MYSQL"
 
+  # Connector type — CDC (default) preserves full backward compatibility with existing configs.
+  # Set connector_type: QBC in the YAML to deploy a query-based connector instead.
+  connector_type = upper(try(local.cfg.connector_type, "CDC"))
+  is_cdc         = local.connector_type == "CDC"
+  is_qbc         = local.connector_type == "QBC"
+
   # Gateway validation toggle - defaults to true if not specified (preserves existing behaviour)
   gateway_validation_enabled = try(local.cfg.gateway_validation.enabled, true)
 
   # Event log configuration - defaults to true if not specified
   event_log_to_table = try(local.cfg.event_log.to_table, true)
+
+  # QBC defaults — only relevant when is_qbc
+  qbc_default_cursor_column = try(local.cfg.qbc.default_cursor_column, null)
+  qbc_default_scd_type      = try(local.cfg.qbc.default_scd_type, "SCD_TYPE_1")
+
+  # Flattened table list for the QBC pipeline, resolving cursor/scd/deletion fields
+  # with the coalesce pattern: per-table override → qbc defaults.
+  qbc_tables = local.is_qbc ? flatten([
+    for pair in local.database_schema_pairs : [
+      for table in pair.specific_tables : {
+        # MySQL has no catalog level; all other sources use the database name as source_catalog.
+        source_catalog      = local.is_mysql ? null : pair.database_name
+        source_schema       = local.is_mysql ? pair.database_name : pair.schema_name
+        source_table        = table.source_table
+        destination_catalog = try(table.destination_catalog, pair.uc_catalog)
+        destination_schema  = try(table.destination_schema, pair.destination_schema)
+        cursor_column       = coalesce(try(table.cursor_column, null), local.qbc_default_cursor_column)
+        scd_type            = coalesce(try(table.scd_type, null), local.qbc_default_scd_type)
+        deletion_condition  = try(table.deletion_condition, null)
+      }
+    ]
+  ]) : []
 
   # Unity Catalog configuration with validation
   # global_uc_catalog is required - if not provided, set to null to force Terraform error

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,15 +2,11 @@
 data "databricks_current_user" "me" {}
 
 
-# Validate staging catalog and schema for gateway pipeline
-module "staging" {
-  source = "./modules/validate_catalog_and_schemas"
+# ── Shared: validate destination catalogs and schemas for both CDC and QBC ────
 
-  catalog_name = local.staging_uc_catalog
-  schemas      = [local.staging_schema_name]
-}
-
-# Validate catalogs and schemas where ingestion pipelines will land data (includes per-table overrides)
+# Validate catalogs and schemas where data will land (includes per-table overrides).
+# Runs for both CDC and QBC — landing_catalogs_map is populated from database_schema_pairs
+# which is derived from cfg.databases regardless of connector_type.
 module "landing_catalog_validation" {
   source   = "./modules/validate_catalog_and_schemas"
   for_each = local.landing_catalogs_map
@@ -19,8 +15,21 @@ module "landing_catalog_validation" {
   schemas      = each.value
 }
 
+
+# ── CDC-only resources ────────────────────────────────────────────────────────
+
+# Validate staging catalog and schema for gateway pipeline (CDC only)
+module "staging" {
+  source = "./modules/validate_catalog_and_schemas"
+  count  = local.is_cdc ? 1 : 0
+
+  catalog_name = local.staging_uc_catalog
+  schemas      = [local.staging_schema_name]
+}
+
 module "gateway" {
   source = "./modules/gateway_pipeline"
+  count  = local.is_cdc ? 1 : 0
 
   name                    = "lf-connect-${local.app_name}-gateway"
   connection_name         = local.connection.name
@@ -37,16 +46,16 @@ module "gateway" {
 module "ingestion" {
   source = "./modules/ingestion_pipeline"
 
-  for_each = { for pair in local.database_schema_pairs : pair.pair_key => pair }
+  for_each = local.is_cdc ? { for pair in local.database_schema_pairs : pair.pair_key => pair } : {}
 
   name                  = local.is_mysql ? "${each.value.pair_key}-ingestion" : "${each.value.database_name}-${each.value.schema_name}-ingestion"
   source_catalog        = local.is_mysql ? "default_catalog" : each.value.database_name
   source_schema         = local.is_mysql ? each.value.database_name : each.value.schema_name
   destination_catalog   = each.value.uc_catalog
   destination_schema    = each.value.destination_schema
-  gateway_pipeline_id   = module.gateway.pipeline_id
+  gateway_pipeline_id   = module.gateway[0].pipeline_id
   source_type           = local.connection.source_type
-  use_schema_ingestion  = local.is_mysql ? false : each.value.use_schema_ingestion # For MySQL, schema-level ingestion is not applicable hence ignore
+  use_schema_ingestion  = local.is_mysql ? false : each.value.use_schema_ingestion
   specific_tables       = each.value.specific_tables
   source_configurations = lookup(local.database_source_configurations, each.value.database_name, null)
   event_log_to_table    = local.event_log_to_table
@@ -59,9 +68,9 @@ module "ingestion" {
 # (useful when pipelines are already running and a validate-only run would fail).
 module "gateway_validation" {
   source = "./modules/gateway_validation"
-  count  = local.gateway_validation_enabled ? 1 : 0
+  count  = (local.is_cdc && local.gateway_validation_enabled) ? 1 : 0
 
-  pipeline_id            = module.gateway.pipeline_id
+  pipeline_id            = module.gateway[0].pipeline_id
   timeout_minutes        = try(local.cfg.gateway_validation.timeout_minutes, 30)
   check_interval_seconds = try(local.cfg.gateway_validation.check_interval_seconds, 15)
   yaml_config_path       = var.yaml_config_path
@@ -73,7 +82,7 @@ module "gateway_validation" {
 module "orchestrator_shared_all_pipelines" {
   source = "./modules/job"
 
-  count = local.job.common_job_for_all_pipelines ? 1 : 0
+  count = (local.is_cdc && local.job.common_job_for_all_pipelines) ? 1 : 0
 
   name                = "lf-connect-${local.app_name}-common-job"
   ingestion_pipelines = { for k, v in module.ingestion : k => v.pipeline_id }
@@ -87,7 +96,7 @@ module "orchestrator_shared_all_pipelines" {
 module "orchestrator_per_schedule" {
   source = "./modules/job"
 
-  for_each = local.job.common_job_for_all_pipelines ? {} : local.schedule_to_pipelines
+  for_each = (local.is_cdc && !local.job.common_job_for_all_pipelines) ? local.schedule_to_pipelines : {}
 
   name = "lf-connect-${local.app_name}-${each.key}"
   ingestion_pipelines = {
@@ -103,3 +112,38 @@ module "orchestrator_per_schedule" {
   depends_on = [module.gateway_validation]
 }
 
+
+# ── QBC-only resources ────────────────────────────────────────────────────────
+
+# Single managed ingestion pipeline for all QBC sources.
+# Uses serverless compute — no gateway pipeline or cluster config required.
+module "qbc" {
+  source = "./modules/qbc_pipeline"
+  count  = local.is_qbc ? 1 : 0
+
+  pipeline_name       = "lf-connect-${local.app_name}-qbc"
+  connection_name     = local.connection.name
+  source_type         = null # serverless — inferred from UC connection
+  # Pipeline-level catalog/schema is required by Databricks even when each table
+  # specifies its own destination. Fall back to the first table's catalog when
+  # global_uc_catalog is null (i.e. per-database uc_catalog overrides are in use).
+  destination_catalog = coalesce(local.global_uc_catalog, local.qbc_tables[0].destination_catalog)
+  destination_schema  = local.qbc_tables[0].destination_schema
+  tables              = local.qbc_tables
+  event_log_to_table  = local.event_log_to_table
+
+  depends_on = [module.landing_catalog_validation]
+}
+
+# Orchestration job for the QBC pipeline — uses common_schedule.
+module "orchestrator_qbc" {
+  source = "./modules/job"
+  count  = local.is_qbc ? 1 : 0
+
+  name                = "lf-connect-${local.app_name}-qbc-job"
+  ingestion_pipelines = { "qbc" = module.qbc[0].pipeline_id }
+  schedule            = local.job.common_schedule
+  is_common_job       = true
+
+  depends_on = [module.qbc]
+}

--- a/infra/modules/qbc_pipeline/main.tf
+++ b/infra/modules/qbc_pipeline/main.tf
@@ -1,0 +1,97 @@
+variable "pipeline_name" {
+  description = "Display name of the QBC pipeline"
+  type        = string
+}
+
+variable "connection_name" {
+  description = "Unity Catalog connection name for the source database"
+  type        = string
+}
+
+variable "source_type" {
+  description = "Source database type (null for serverless — inferred from UC connection)"
+  type        = string
+  default     = null
+}
+
+variable "destination_catalog" {
+  description = "Default destination catalog in Unity Catalog"
+  type        = string
+}
+
+variable "destination_schema" {
+  description = "Nominal pipeline-level destination schema (overridden per table object)"
+  type        = string
+}
+
+variable "tables" {
+  description = "Flattened list of tables to ingest with resolved cursor/scd/deletion fields"
+  type = list(object({
+    source_catalog      = optional(string, null) # null for MySQL/MariaDB (no catalog level)
+    source_schema       = string
+    source_table        = string
+    destination_catalog = string
+    destination_schema  = string
+    cursor_column       = string
+    scd_type            = string
+    deletion_condition  = optional(string, null)
+  }))
+}
+
+variable "event_log_to_table" {
+  description = "Whether to materialize event logs to Delta tables"
+  type        = bool
+  default     = true
+}
+
+resource "databricks_pipeline" "qbc" {
+  name = var.pipeline_name
+
+  catalog = var.destination_catalog
+  schema  = var.destination_schema
+
+  dynamic "event_log" {
+    for_each = var.event_log_to_table ? [1] : []
+    content {
+      name = "event_log_${var.pipeline_name}"
+    }
+  }
+
+  ingestion_definition {
+    connection_name = var.connection_name
+
+    # null = serverless (Databricks infers source type from the UC connection).
+    # Set explicitly only if required for your source/compute combination.
+    source_type = var.source_type
+
+    dynamic "objects" {
+      for_each = var.tables
+      content {
+        table {
+          source_catalog = objects.value.source_catalog
+          source_schema  = objects.value.source_schema
+          source_table   = objects.value.source_table
+
+          destination_catalog = objects.value.destination_catalog
+          destination_schema  = objects.value.destination_schema
+          # destination_table omitted — defaults to lowercase(source_table)
+
+          table_configuration {
+            scd_type = objects.value.scd_type
+
+            query_based_connector_config {
+              cursor_columns = [objects.value.cursor_column]
+              # Only set deletion_condition when explicitly provided
+              deletion_condition = objects.value.deletion_condition
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+output "pipeline_id" {
+  description = "QBC pipeline ID"
+  value       = databricks_pipeline.qbc.id
+}

--- a/infra/modules/qbc_pipeline/versions.tf
+++ b/infra/modules/qbc_pipeline/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = ">= 1.104.0"
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -12,11 +12,6 @@ output "landing_catalogs" {
   value       = { for k, v in module.landing_catalog_validation : k => v.catalog_name }
 }
 
-output "staging_catalog" {
-  description = "Staging catalog for gateway pipeline"
-  value       = module.staging.catalog_name
-}
-
 output "landing_schemas_by_catalog" {
   description = "Landing schemas grouped by catalog"
   value = {
@@ -29,17 +24,33 @@ output "landing_schemas_by_catalog" {
   }
 }
 
+
+# ── CDC-only outputs ──────────────────────────────────────────────────────────
+
+output "staging_catalog" {
+  description = "Staging catalog for gateway pipeline (CDC only)"
+  value       = length(module.staging) > 0 ? module.staging[0].catalog_name : null
+}
+
 output "gateway_pipeline_id" {
-  description = "Gateway pipeline ID"
-  value       = module.gateway.pipeline_id
+  description = "Gateway pipeline ID (CDC only)"
+  value       = length(module.gateway) > 0 ? module.gateway[0].pipeline_id : null
 }
 
 output "ingestion_pipeline_id_map" {
-  description = "Ingestion pipeline IDs mapped by pipeline name"
+  description = "Ingestion pipeline IDs mapped by pipeline name (CDC only)"
   value       = { for k, v in module.ingestion : k => v.pipeline_id }
 }
 
 output "common_orchestrator_all_pipelines" {
-  description = "Key value pair of job name and ID"
+  description = "Key value pair of job name and ID (CDC only)"
   value       = length(module.orchestrator_shared_all_pipelines) > 0 ? module.orchestrator_shared_all_pipelines[0].common_orchestrator_all_pipelines : {}
-} 
+}
+
+
+# ── QBC-only outputs ──────────────────────────────────────────────────────────
+
+output "qbc_pipeline_id" {
+  description = "QBC pipeline ID (QBC only)"
+  value       = length(module.qbc) > 0 ? module.qbc[0].pipeline_id : null
+}

--- a/tools/pydantic_validator.py
+++ b/tools/pydantic_validator.py
@@ -135,7 +135,7 @@ class JobConfig(BaseModel):
 
 class TableConfig(BaseModel):
     """Table selection configuration."""
-    
+
     source_table: str = Field(
         ...,
         description="Source table name"
@@ -152,13 +152,38 @@ class TableConfig(BaseModel):
         default=None,
         description="Override destination schema for this table (defaults to schema/database-level schema)"
     )
-    
+    # QBC-specific fields (optional; may also be set via qbc.default_cursor_column / qbc.default_scd_type)
+    cursor_column: Optional[str] = Field(
+        default=None,
+        description="QBC: column used as cursor for incremental sync (overrides qbc.default_cursor_column)"
+    )
+    scd_type: Optional[str] = Field(
+        default=None,
+        description="QBC: SCD strategy — SCD_TYPE_1, SCD_TYPE_2, or APPEND_ONLY (overrides qbc.default_scd_type)"
+    )
+    deletion_condition: Optional[str] = Field(
+        default=None,
+        description="QBC: SQL expression to identify soft-deleted rows (optional)"
+    )
+
     @field_validator("source_table")
     @classmethod
     def validate_table_name(cls, v: str) -> str:
         """Validate table name is non-empty."""
         if not v or not v.strip():
             raise ValueError("Table name cannot be empty")
+        return v
+
+    @field_validator("scd_type")
+    @classmethod
+    def validate_scd_type(cls, v: Optional[str]) -> Optional[str]:
+        """Validate scd_type is one of the allowed values."""
+        if v is not None:
+            allowed = {"SCD_TYPE_1", "SCD_TYPE_2", "APPEND_ONLY"}
+            if v not in allowed:
+                raise ValueError(
+                    f"scd_type must be one of {sorted(allowed)}, got: {v!r}"
+                )
         return v
 
 
@@ -398,6 +423,30 @@ class GatewayValidationConfig(BaseModel):
     check_interval_seconds: int = Field(default=15, ge=5)
 
 
+class QBCConfig(BaseModel):
+    """Query-Based Connector defaults applied across all tables."""
+
+    default_cursor_column: Optional[str] = Field(
+        default=None,
+        description="Default cursor column for incremental sync (overridden per-table)"
+    )
+    default_scd_type: str = Field(
+        default="SCD_TYPE_1",
+        description="Default SCD strategy — SCD_TYPE_1, SCD_TYPE_2, or APPEND_ONLY"
+    )
+
+    @field_validator("default_scd_type")
+    @classmethod
+    def validate_default_scd_type(cls, v: str) -> str:
+        """Validate default_scd_type is one of the allowed values."""
+        allowed = {"SCD_TYPE_1", "SCD_TYPE_2", "APPEND_ONLY"}
+        if v not in allowed:
+            raise ValueError(
+                f"qbc.default_scd_type must be one of {sorted(allowed)}, got: {v!r}"
+            )
+        return v
+
+
 class EventLogConfig(BaseModel):
     """Event log configuration."""
     
@@ -419,7 +468,7 @@ class EventLogConfig(BaseModel):
 
 class LakeflowConfig(BaseModel):
     """Root configuration model for Lakeflow Connect."""
-    
+
     env: str = Field(
         ...,
         description="Environment name (e.g., 'dev', 'prod')"
@@ -428,6 +477,10 @@ class LakeflowConfig(BaseModel):
         ...,
         description="Application name"
     )
+    connector_type: str = Field(
+        default="CDC",
+        description="Connector mode: CDC (Change Data Capture) or QBC (Query-Based Connector)"
+    )
     unity_catalog: Optional[UnityCatalogConfig] = Field(
         default=None,
         description="Unity Catalog configuration"
@@ -435,20 +488,32 @@ class LakeflowConfig(BaseModel):
     connection: ConnectionConfig
     gateway_pipeline_cluster_policy_name: Optional[str] = Field(
         default=None,
-        description="Cluster policy name for gateway pipeline"
+        description="Cluster policy name for gateway pipeline (CDC only)"
     )
     databases: list[DatabaseConfig] = Field(
         ...,
         min_length=1,
         description="List of source databases"
     )
-    gateway_pipeline_cluster_config: GatewayPipelineClusterConfig
-    gateway_validation: GatewayValidationConfig
+    # CDC-only: required when connector_type is CDC
+    gateway_pipeline_cluster_config: Optional[GatewayPipelineClusterConfig] = Field(
+        default=None,
+        description="Gateway pipeline cluster configuration (CDC only)"
+    )
+    gateway_validation: Optional[GatewayValidationConfig] = Field(
+        default=None,
+        description="Gateway validation settings (CDC only)"
+    )
     event_log: Optional[EventLogConfig] = Field(
         default=None,
         description="Event log configuration"
     )
     job: JobConfig
+    # QBC-only: optional defaults applied across all tables
+    qbc: Optional[QBCConfig] = Field(
+        default=None,
+        description="Query-Based Connector defaults (QBC only)"
+    )
     
     @field_validator("env", "app_name")
     @classmethod
@@ -457,68 +522,113 @@ class LakeflowConfig(BaseModel):
         if not v or not v.strip():
             raise ValueError("Value must be a non-empty string")
         return v
-    
+
+    @field_validator("connector_type")
+    @classmethod
+    def validate_connector_type(cls, v: str) -> str:
+        """Validate connector_type is CDC or QBC."""
+        normalised = v.upper()
+        if normalised not in {"CDC", "QBC"}:
+            raise ValueError(
+                f"connector_type must be 'CDC' or 'QBC', got: {v!r}"
+            )
+        return normalised
+
+    @model_validator(mode="after")
+    def validate_cdc_specific_fields(self):
+        """For CDC, gateway_pipeline_cluster_config is required."""
+        if self.connector_type == "CDC":
+            if self.gateway_pipeline_cluster_config is None:
+                raise ValueError(
+                    "gateway_pipeline_cluster_config is required for CDC connector type"
+                )
+        return self
+
     @model_validator(mode="after")
     def validate_unity_catalog_configuration(self):
         """
-        Validate Unity Catalog configuration logic:
-        - Either global_uc_catalog exists, OR
-        - (staging_uc_catalog exists AND all databases have uc_catalog)
+        Validate Unity Catalog configuration logic.
+
+        CDC:
+          - global_uc_catalog set → OK
+          - global_uc_catalog absent → staging_uc_catalog required AND every database must have uc_catalog
+
+        QBC:
+          - global_uc_catalog set → OK (used as fallback for any database without uc_catalog)
+          - global_uc_catalog absent / unity_catalog omitted → every database must have uc_catalog
+            (the unity_catalog section can be omitted entirely in this case)
         """
         uc_config = self.unity_catalog
-        
-        if uc_config is None:
-            raise ValueError(
-                "unity_catalog configuration is required. "
-                "Must provide either global_uc_catalog or (staging_uc_catalog + per-database uc_catalog for all databases)"
-            )
-        
-        has_global = uc_config.global_uc_catalog is not None
-        has_staging = uc_config.staging_uc_catalog is not None
-        
+        is_qbc = self.connector_type == "QBC"
+
+        has_global = uc_config is not None and uc_config.global_uc_catalog is not None
+        has_staging = uc_config is not None and uc_config.staging_uc_catalog is not None
+
         if not has_global:
-            # If no global catalog, must have staging catalog
-            if not has_staging:
-                raise ValueError(
-                    "unity_catalog.staging_uc_catalog is required when global_uc_catalog is not provided"
-                )
-            
-            # AND all databases must have uc_catalog specified
+            # CDC requires the unity_catalog block and a staging catalog
+            if not is_qbc:
+                if uc_config is None:
+                    raise ValueError(
+                        "unity_catalog configuration is required for CDC. "
+                        "Provide global_uc_catalog, or staging_uc_catalog + per-database uc_catalog."
+                    )
+                if not has_staging:
+                    raise ValueError(
+                        "unity_catalog.staging_uc_catalog is required for CDC "
+                        "when global_uc_catalog is not provided"
+                    )
+
+            # Both CDC and QBC: without a global fallback every database must name its own catalog
             databases_without_catalog = [
                 db.name for db in self.databases if db.uc_catalog is None
             ]
-            
             if databases_without_catalog:
                 raise ValueError(
-                    f"When unity_catalog.global_uc_catalog is not provided, all databases must specify uc_catalog. "
-                    f"Missing for: {', '.join(databases_without_catalog)}"
+                    "When unity_catalog.global_uc_catalog is not provided, every database must "
+                    "specify uc_catalog. Missing for: "
+                    + ", ".join(databases_without_catalog)
                 )
-        
+
         return self
     
     @model_validator(mode="after")
     def validate_postgresql_configuration(self):
         """
         Validate PostgreSQL-specific configuration:
-        - If source_type is POSTGRESQL, databases MUST have replication_slot and publication
-        - If source_type is not POSTGRESQL, these fields should NOT be present
+        - CDC + POSTGRESQL: databases MUST have replication_slot and publication
+        - QBC + POSTGRESQL: replication_slot and publication are NOT required
+        - Non-POSTGRESQL: these fields should NOT be present
         """
         source_type = self.connection.source_type
-        
+        is_qbc = self.connector_type == "QBC"
+
         for db in self.databases:
             has_replication = db.replication_slot is not None
             has_publication = db.publication is not None
-            
+
             if source_type == "POSTGRESQL":
-                # PostgreSQL requires both fields
-                if not has_replication:
-                    raise ValueError(
-                        f"Database '{db.name}': replication_slot is required for PostgreSQL source_type"
-                    )
-                if not has_publication:
-                    raise ValueError(
-                        f"Database '{db.name}': publication is required for PostgreSQL source_type"
-                    )
+                if is_qbc:
+                    # QBC uses the UC connection — no replication slot / publication needed
+                    if has_replication:
+                        raise ValueError(
+                            f"Database '{db.name}': replication_slot is not used for QBC "
+                            f"PostgreSQL sources (QBC connects via Unity Catalog)"
+                        )
+                    if has_publication:
+                        raise ValueError(
+                            f"Database '{db.name}': publication is not used for QBC "
+                            f"PostgreSQL sources (QBC connects via Unity Catalog)"
+                        )
+                else:
+                    # CDC + PostgreSQL requires both fields
+                    if not has_replication:
+                        raise ValueError(
+                            f"Database '{db.name}': replication_slot is required for PostgreSQL CDC"
+                        )
+                    if not has_publication:
+                        raise ValueError(
+                            f"Database '{db.name}': publication is required for PostgreSQL CDC"
+                        )
             else:
                 # Non-PostgreSQL should not have these fields
                 if has_replication:
@@ -531,7 +641,7 @@ class LakeflowConfig(BaseModel):
                         f"Database '{db.name}': publication is only valid for PostgreSQL sources, "
                         f"but source_type is {source_type}"
                     )
-        
+
         return self
     
     @model_validator(mode="after")
@@ -551,6 +661,38 @@ class LakeflowConfig(BaseModel):
                         file=sys.stderr,
                     )
                     return self  # One warning is enough
+        return self
+
+    @model_validator(mode="after")
+    def validate_qbc_configuration(self):
+        """
+        Validate QBC-specific configuration:
+        - Every table must have a resolved cursor_column (per-table or via qbc.default_cursor_column).
+        - use_schema_ingestion must be false for every schema (QBC only supports explicit table lists).
+        """
+        if self.connector_type != "QBC":
+            return self
+
+        default_cursor = self.qbc.default_cursor_column if self.qbc else None
+
+        for db in self.databases:
+            for schema in db.schemas:
+                if schema.use_schema_ingestion:
+                    raise ValueError(
+                        f"Database '{db.name}', schema '{schema.name}': "
+                        f"use_schema_ingestion must be false for QBC — "
+                        f"provide an explicit tables list with cursor_column"
+                    )
+                tables = schema.tables or []
+                for table in tables:
+                    resolved_cursor = table.cursor_column or default_cursor
+                    if not resolved_cursor:
+                        raise ValueError(
+                            f"Database '{db.name}', schema '{schema.name}', "
+                            f"table '{table.source_table}': cursor_column is required for QBC. "
+                            f"Set it on the table or via qbc.default_cursor_column."
+                        )
+
         return self
 
     @model_validator(mode="after")
@@ -641,6 +783,7 @@ def validate_yaml(path: Path) -> int:
         print("SUCCESS. YAML validation passed!")
         print(f"   - Environment: {config.env}")
         print(f"   - Application: {config.app_name}")
+        print(f"   - Connector type: {config.connector_type}")
         print(f"   - Source type: {config.connection.source_type}")
         print(f"   - Databases: {len(config.databases)}")
         print(f"   - Event logs to table: {config.event_log.to_table if config.event_log else 'Not configured'}")


### PR DESCRIPTION
Introduces connector_type: QBC as an alternative to CDC. QBC uses serverless compute and SQL polling — no gateway pipeline, no cluster config, no replication slot required.

Terraform changes:
- New module infra/modules/qbc_pipeline/ — single databricks_pipeline with ingestion_definition, dynamic per-table objects, event_log, and query_based_connector_config (cursor_columns, scd_type, deletion_condition)
- infra/locals.tf — connector_type, is_cdc/is_qbc flags, qbc_tables local (resolves per-table cursor/scd overrides against qbc defaults)
- infra/main.tf — full CDC/QBC conditional routing; module.qbc and module.orchestrator_qbc; pipeline-level catalog falls back to first table's destination_catalog when global_uc_catalog is null
- infra/outputs.tf — CDC outputs made conditional; qbc_pipeline_id added
- infra/.terraform.lock.hcl — bump databricks provider 1.104.0 → 1.113.0

Pydantic validator changes:
- New QBCConfig model (default_cursor_column, default_scd_type)
- TableConfig gains optional cursor_column, scd_type, deletion_condition
- connector_type field with CDC/QBC validation
- gateway_pipeline_cluster_config made Optional (not required for QBC)
- validate_unity_catalog_configuration: unity_catalog section may be omitted for QBC when every database specifies its own uc_catalog
- validate_postgresql_configuration: skips replication_slot/publication check for QBC (CDC-only requirement)
- validate_qbc_configuration: enforces use_schema_ingestion=false and resolved cursor_column for every table

Example and docs:
- config/examples/postgresql_qbc.yml — two-database PostgreSQL QBC example with per-database uc_catalog overrides, correct cursor columns per DDL (transaction_date for transactions, updated_at elsewhere)
- docs/yaml-configuration.md — new Connector Type and QBC sections

Co-authored-by: Isaac