### PR TITLE
feat(qbc): add Oracle QBC example config and fix Oracle CDC-only validator

### DIFF
--- a/config/examples/oracle_qbc.yml
+++ b/config/examples/oracle_qbc.yml
@@ -1,0 +1,81 @@
+# Query-Based Connector (QBC) example — Oracle
+#
+# Use connector_type: QBC when you want Databricks to issue SQL queries
+# for incremental sync instead of streaming CDC events via a gateway pipeline.
+# QBC uses serverless compute; no gateway pipeline or cluster config is required.
+#
+# Note: Oracle identifiers (schemas, tables, cursor columns) are typically
+# uppercase — match the case exactly as they appear in the source database.
+
+env: "dev"
+app_name: "wealth_mgmt_oracle_qbc"
+
+connector_type: QBC
+
+# UC connection name for the source database (must already exist in Unity Catalog)
+connection:
+  name: "amenon_lf_connect_oracle19c-query-based-connector"
+  source_type: "ORACLE"
+  # Note: connection_parameters (source_catalog / CDB name) is NOT needed for QBC —
+  # QBC connects via the Unity Catalog connection, not the CDC replication path.
+
+
+# To use a single shared catalog instead, add the following block (omit if using per-database uc_catalog overrides)
+#   unity_catalog:
+#     global_uc_catalog: "my_catalog"
+
+# QBC defaults — applied to all tables unless overridden per-table
+qbc:
+  default_cursor_column: "UPDATED_AT"   # Column used for incremental reads (uppercase for Oracle)
+  default_scd_type: "SCD_TYPE_1"        # SCD_TYPE_1, SCD_TYPE_2, or APPEND_ONLY
+
+# Databases and tables to ingest.
+# QBC requires use_schema_ingestion: false — tables must be listed explicitly.
+# Each database overrides uc_catalog so its tables land in a dedicated catalog.
+# In Oracle, the "database" corresponds to the PDB (pluggable database) name.
+databases:
+  - name: ORAPDB1
+    uc_catalog: "amenon"   # per-database catalog override
+    schemas:
+      - name: CLIENT_MANAGEMENT
+        use_schema_ingestion: false
+        tables:
+          - source_table: ACCOUNTS       # inherits default_cursor_column (UPDATED_AT) and default_scd_type
+          - source_table: ADVISORS
+          - source_table: CLIENTS
+            scd_type: "SCD_TYPE_2"       # track full client history; cursor stays UPDATED_AT
+      # - name: PORTFOLIO_MANAGEMENT
+      #   use_schema_ingestion: false
+      #   tables:
+      #     - source_table: HOLDINGS
+      #     - source_table: PORTFOLIOS
+      #     - source_table: TRANSACTIONS
+      #       cursor_column: "TRANSACTION_DATE"  # TRANSACTIONS has no UPDATED_AT column
+      #       scd_type: "APPEND_ONLY"            # transactions are immutable — append only
+
+  # - name: ORAPDB2
+  #   uc_catalog: "lf_connect_qbc_oracle_pdb2"   # per-database catalog override
+  #   schemas:
+  #     - name: CLIENT_MANAGEMENT
+  #       use_schema_ingestion: false
+  #       tables:
+  #         - source_table: ACCOUNTS
+  #         - source_table: CLIENTS
+  #     - name: PORTFOLIO_MANAGEMENT
+  #       use_schema_ingestion: false
+  #       tables:
+  #         - source_table: HOLDINGS
+  #         - source_table: TRANSACTIONS
+  #           cursor_column: "TRANSACTION_DATE"
+  #           scd_type: "APPEND_ONLY"
+
+# Event log configuration
+event_log:
+  to_table: true
+
+# Job orchestration — QBC always uses the common schedule
+job:
+  common_job_for_all_pipelines: true
+  common_schedule:
+    quartz_cron_expression: "0 0 * * * ?"   # Run every hour
+    timezone_id: "UTC"

--- a/tools/pydantic_validator.py
+++ b/tools/pydantic_validator.py
@@ -358,21 +358,14 @@ class ConnectionConfig(BaseModel):
     @model_validator(mode="after")
     def validate_oracle_connection_parameters(self):
         """
-        When source_type is ORACLE, connection_parameters with source_catalog is required.
-        When source_type is not ORACLE, connection_parameters must not be set.
+        connection_parameters is only valid for Oracle sources.
+        Whether it is *required* depends on connector_type (CDC only) — checked in AppConfig.
         """
-        if self.source_type == "ORACLE":
-            if self.connection_parameters is None:
-                raise ValueError(
-                    "connection.connection_parameters is required when source_type is ORACLE "
-                    "(e.g. connection_parameters.source_catalog for the CDB name)"
-                )
-        else:
-            if self.connection_parameters is not None:
-                raise ValueError(
-                    f"connection.connection_parameters is only valid for Oracle sources, "
-                    f"but source_type is {self.source_type}"
-                )
+        if self.source_type != "ORACLE" and self.connection_parameters is not None:
+            raise ValueError(
+                f"connection.connection_parameters is only valid for Oracle sources, "
+                f"but source_type is {self.source_type}"
+            )
         return self
 
 
@@ -536,11 +529,16 @@ class LakeflowConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_cdc_specific_fields(self):
-        """For CDC, gateway_pipeline_cluster_config is required."""
+        """For CDC, gateway_pipeline_cluster_config and Oracle connection_parameters are required."""
         if self.connector_type == "CDC":
             if self.gateway_pipeline_cluster_config is None:
                 raise ValueError(
                     "gateway_pipeline_cluster_config is required for CDC connector type"
+                )
+            if self.connection.source_type == "ORACLE" and self.connection.connection_parameters is None:
+                raise ValueError(
+                    "connection.connection_parameters is required for Oracle CDC "
+                    "(e.g. connection_parameters.source_catalog for the CDB name)"
                 )
         return self
 


### PR DESCRIPTION
- Add config/examples/oracle_qbc.yml: Oracle QBC example using the same wealth management theme as postgresql_qbc.yml, with uppercase Oracle identifiers and per-database uc_catalog overrides
- Fix pydantic_validator: connection_parameters requirement for Oracle moved from ConnectionConfig (no connector_type visibility) to AppConfig.validate_cdc_specific_fields — QBC Oracle configs no longer require connection_parameters (CDB name is CDC-only)