### PR TITLE
  feat: multi-cloud auth, detect-changes CI job, and QBC destination_table override

### DIFF
--- a/.github/workflows/full-refresh-pipeline.yml
+++ b/.github/workflows/full-refresh-pipeline.yml
@@ -14,7 +14,9 @@
 #
 # Prerequisites:
 #   - GitHub Environment "production-refresh" with required reviewers configured
-#   - Repository secrets: DATABRICKS_HOST, DEPLOY_SPN_CLIENT_ID, DEPLOY_SPN_CLIENT_SECRET, ARM_TENANT_ID
+#   - Repository secrets: DATABRICKS_HOST, and one of:
+#       Option A (OAuth M2M, Azure or AWS): DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+#       Option B (Azure SPN only): DEPLOY_SPN_CLIENT_ID, DEPLOY_SPN_CLIENT_SECRET, ARM_TENANT_ID
 #   - Terraform outputs available (pipeline IDs)
 # =============================================================================
 
@@ -57,6 +59,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
+
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Display refresh plan
         run: |
@@ -104,7 +114,13 @@ jobs:
     #     url: ${{ format('https://{0}/#job/{1}/pipelines/{2}', secrets.DATABRICKS_HOST, github.run_id, github.event.inputs.pipeline_id) }}
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      # Databricks SDK Azure service principal auth (same SPN used by Terraform provider)
+      # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+      # both credential sets are present to avoid "more than one auth method" error.
+      DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+      # OAuth M2M (Azure or AWS workspaces)
+      DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+      # Azure SPN (Entra ID) — Azure workspaces only
       ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
@@ -112,9 +128,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --break-system-packages databricks-sdk -q
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Create audit log entry
         run: |

--- a/.github/workflows/full-refresh-tables.yml
+++ b/.github/workflows/full-refresh-tables.yml
@@ -23,7 +23,9 @@
 #
 # Prerequisites:
 #   - GitHub Environment "production-refresh" with required reviewers configured
-#   - Repository secrets: DATABRICKS_HOST, DEPLOY_SPN_CLIENT_ID/SECRET, ARM_TENANT_ID
+#   - Repository secrets: DATABRICKS_HOST, and one of:
+#       Option A (OAuth M2M, Azure or AWS): DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+#       Option B (Azure SPN only): DEPLOY_SPN_CLIENT_ID, DEPLOY_SPN_CLIENT_SECRET, ARM_TENANT_ID
 #   - Terraform outputs available (pipeline IDs)
 # =============================================================================
 
@@ -67,6 +69,13 @@ jobs:
     runs-on: self-hosted
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+      # both credential sets are present to avoid "more than one auth method" error.
+      DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+      # OAuth M2M (Azure or AWS workspaces)
+      DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+      # Azure SPN (Entra ID) — Azure workspaces only
       ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
@@ -76,6 +85,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
+
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Parse and validate table name format
         id: parse
@@ -120,10 +137,6 @@ jobs:
           echo "  Only the above tables will be fully refreshed."
           echo "  Other tables in the pipeline will continue CDC."
           echo "============================================"
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --break-system-packages databricks-sdk -q
 
       - name: Verify tables exist in Unity Catalog
         run: |
@@ -193,6 +206,13 @@ jobs:
     #     url: ${{ format('https://{0}/#job/{1}/pipelines/{2}', secrets.DATABRICKS_HOST, github.run_id, github.event.inputs.pipeline_id) }}
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+      # both credential sets are present to avoid "more than one auth method" error.
+      DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+      # OAuth M2M (Azure or AWS workspaces)
+      DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+      # Azure SPN (Entra ID) — Azure workspaces only
       ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
@@ -200,9 +220,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --break-system-packages databricks-sdk -q
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Create audit log entry
         run: |

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -15,11 +15,21 @@
 #
 # Self-hosted runner prerequisites: python, pip3, terraform
 #
-# Authentication model (two separate SPNs):
+# Authentication model:
 #   TF_STATE_SPN  - Azure SP with Storage Blob Data Contributor on tf-state
 #                   container. Used ONLY for terraform init (azurerm backend).
-#   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
-#                   principal. Used for terraform plan/apply (Databricks provider).
+#   DEPLOY identity - Authenticates to the Databricks workspace for plan/apply.
+#                   Supports two methods; the SDK picks whichever secrets are set
+#                   (OAuth M2M takes precedence per Databricks unified auth order):
+#
+#   Option A — OAuth M2M (Azure or AWS workspaces):
+#     DATABRICKS_CLIENT_ID     = Databricks service principal OAuth client ID
+#     DATABRICKS_CLIENT_SECRET = Databricks service principal OAuth client secret
+#
+#   Option B — Azure SPN / Entra ID (Azure workspaces only):
+#     DEPLOY_SPN_CLIENT_ID     = Azure AD application (client) ID  → ARM_CLIENT_ID
+#     DEPLOY_SPN_CLIENT_SECRET = Azure AD client secret            → ARM_CLIENT_SECRET
+#     ARM_TENANT_ID            = Azure AD tenant ID
 #
 # Repository variables (azurerm partial backend — state blob location):
 #   TF_STATE_RESOURCE_GROUP, TF_STATE_STORAGE_ACCOUNT, TF_STATE_CONTAINER, TF_STATE_KEY
@@ -41,13 +51,11 @@
 name: "Terraform Deploy - Lakeflow Connect"
 
 on:
-  # Run validate + plan on PRs targeting main (when infra or config changes)
+  # Run validate + plan on all PRs targeting main.
+  # A 'changes' job detects whether infra/config/tools files were touched;
+  # if not, a lightweight skip job satisfies the required 'Plan' status check.
   pull_request:
     branches: [main]
-    paths:
-      - "infra/**"
-      - "config/**"
-      - "tools/**"
 
   # Manual trigger for full deploy (plan + apply)
   workflow_dispatch:
@@ -77,24 +85,59 @@ env:
 
 jobs:
   # -------------------------------------------------------------------------
+  # Job 0: Detect whether infra/config/tools files changed
+  # Always runs; outputs infra=true/false used by downstream jobs.
+  # On workflow_dispatch (no PR context) always outputs true.
+  # -------------------------------------------------------------------------
+  changes:
+    name: "Detect Changes"
+    runs-on: self-hosted
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Check for infra/config/tools changes
+        id: filter
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "infra=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if git diff --name-only \
+               "${{ github.event.pull_request.base.sha }}" \
+               "${{ github.event.pull_request.head.sha }}" \
+             | grep -qE '^(infra|config|tools)/'; then
+            echo "infra=true" >> $GITHUB_OUTPUT
+          else
+            echo "infra=false" >> $GITHUB_OUTPUT
+          fi
+
+  # -------------------------------------------------------------------------
   # Job 1: Validate config and Terraform files
   # -------------------------------------------------------------------------
   validate:
     name: "Validate"
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
     runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Set up Python venv and install dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install pydantic pyyaml croniter
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Validate YAML config with Pydantic
         run: |
-          source .venv/bin/activate
           CONFIG_PATH="${{ github.event.inputs.config_file || 'config/lakeflow_dev.yml' }}"
           # Adjust path for validator (it expects path relative to repo root)
           if [[ "$CONFIG_PATH" == ../config/* ]]; then
@@ -126,11 +169,12 @@ jobs:
         run: terraform validate
 
   # -------------------------------------------------------------------------
-  # Job 2: Terraform Plan (always runs)
+  # Job 2a: Terraform Plan — runs only when infra/config/tools files changed
   # -------------------------------------------------------------------------
   plan:
     name: "Plan"
-    needs: validate
+    needs: [changes, validate]
+    if: needs.changes.outputs.infra == 'true'
     runs-on: self-hosted
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
@@ -138,23 +182,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Set up Python venv and install dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install databricks-sdk pyyaml
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Terraform Init and Plan
         id: plan
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
-          # DEPLOY_SPN credentials as ARM_* — used by Databricks provider for
-          # azure-client-secret auth during plan. Also provides subscription ID.
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+          # both credential sets are present to avoid "more than one auth method" error.
+          DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+          # OAuth M2M (Azure or AWS workspaces)
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          # Azure SPN (Entra ID) — Azure workspaces only
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           set -o pipefail
 
@@ -217,6 +268,22 @@ jobs:
       #     retention-days: 1
 
   # -------------------------------------------------------------------------
+  # Job 2b: Skip plan for docs-only PRs
+  # Satisfies the required 'Plan' status check when no infra files changed.
+  # -------------------------------------------------------------------------
+  plan-skip:
+    name: "Plan"
+    needs: changes
+    if: always() && needs.changes.outputs.infra != 'true' && github.event_name == 'pull_request'
+    runs-on: self-hosted
+    steps:
+      - name: Skip — no infra/config/tools changes
+        run: |
+          echo "## Plan Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No changes detected in \`infra/\`, \`config/\`, or \`tools/\` — plan is not required for this PR." >> $GITHUB_STEP_SUMMARY
+
+  # -------------------------------------------------------------------------
   # Job 3: Terraform Apply
   # Runs init + plan + apply in the same job.
   # NOTE: For approval gates, configure a GitHub Environment with required
@@ -238,20 +305,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Install Python dependencies for local-exec
-        run: |
-          pip3 install --break-system-packages databricks-sdk pyyaml
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Terraform Init, Plan, and Apply
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
-          # DEPLOY_SPN credentials as ARM_* — used by Databricks provider for
-          # azure-client-secret auth. Also provides subscription ID.
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+          # both credential sets are present to avoid "more than one auth method" error.
+          DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+          # OAuth M2M (Azure or AWS workspaces)
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          # Azure SPN (Entra ID) — Azure workspaces only
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           set -o pipefail
 
@@ -303,11 +379,13 @@ jobs:
         if: github.event.inputs.action == 'plan-and-apply'
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployed Resources" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-output-pipeline-ids.yml
+++ b/.github/workflows/terraform-output-pipeline-ids.yml
@@ -32,6 +32,13 @@ jobs:
     runs-on: self-hosted
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+      # both credential sets are present to avoid "more than one auth method" error.
+      DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+      # OAuth M2M (Azure or AWS workspaces)
+      DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+      # Azure SPN (Entra ID) — Azure workspaces only
       ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
@@ -59,23 +66,32 @@ jobs:
           echo "## Pipeline IDs for ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          echo "### Gateway Pipeline" >> $GITHUB_STEP_SUMMARY
-          GATEWAY_ID=$(terraform output -raw gateway_pipeline_id 2>/dev/null || echo "N/A")
-          echo "| Pipeline | ID |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-----|" >> $GITHUB_STEP_SUMMARY
-          echo "| Gateway | \`$GATEWAY_ID\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          QBC_ID=$(terraform output -raw qbc_pipeline_id 2>/dev/null || true)
 
-          echo "### Ingestion Pipelines" >> $GITHUB_STEP_SUMMARY
-          echo "| Pipeline Key | Pipeline ID |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------------|-------------|" >> $GITHUB_STEP_SUMMARY
-          terraform output -json ingestion_pipeline_id_map 2>/dev/null | \
-            python -c "
+          if [[ -n "$QBC_ID" && "$QBC_ID" != "null" ]]; then
+            echo "### QBC Pipeline" >> $GITHUB_STEP_SUMMARY
+            echo "| Pipeline | ID |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|-----|" >> $GITHUB_STEP_SUMMARY
+            echo "| QBC | \`$QBC_ID\` |" >> $GITHUB_STEP_SUMMARY
+          else
+            GATEWAY_ID=$(terraform output -raw gateway_pipeline_id 2>/dev/null || echo "N/A")
+            echo "### Gateway Pipeline" >> $GITHUB_STEP_SUMMARY
+            echo "| Pipeline | ID |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|-----|" >> $GITHUB_STEP_SUMMARY
+            echo "| Gateway | \`$GATEWAY_ID\` |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            echo "### Ingestion Pipelines" >> $GITHUB_STEP_SUMMARY
+            echo "| Pipeline Key | Pipeline ID |" >> $GITHUB_STEP_SUMMARY
+            echo "|-------------|-------------|" >> $GITHUB_STEP_SUMMARY
+            terraform output -json ingestion_pipeline_id_map 2>/dev/null | \
+              python -c "
           import json, sys
           data = json.load(sys.stdin)
           for key, pid in sorted(data.items()):
               print(f'| \`{key}\` | \`{pid}\` |')
           " >> $GITHUB_STEP_SUMMARY || echo "| N/A | Could not retrieve |" >> $GITHUB_STEP_SUMMARY
+          fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "*Use these pipeline IDs when triggering full refresh workflows.*" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-release.yml
+++ b/.github/workflows/terraform-release.yml
@@ -52,11 +52,21 @@
 #
 # Config file: config/lakeflow_dev.yml
 #
-# Authentication model (two separate SPNs):
+# Authentication model:
 #   TF_STATE_SPN  - Azure SP with Storage Blob Data Contributor on tf-state
 #                   container. Used ONLY for terraform init (azurerm backend).
-#   DEPLOY_SPN    - Azure SP registered in Databricks workspace as a service
-#                   principal. Used for terraform plan/apply (Databricks provider).
+#   DEPLOY identity - Authenticates to the Databricks workspace for plan/apply.
+#                   Supports two methods; the SDK picks whichever secrets are set
+#                   (OAuth M2M takes precedence per Databricks unified auth order):
+#
+#   Option A — OAuth M2M (Azure or AWS workspaces):
+#     DATABRICKS_CLIENT_ID     = Databricks service principal OAuth client ID
+#     DATABRICKS_CLIENT_SECRET = Databricks service principal OAuth client secret
+#
+#   Option B — Azure SPN / Entra ID (Azure workspaces only):
+#     DEPLOY_SPN_CLIENT_ID     = Azure AD application (client) ID  → ARM_CLIENT_ID
+#     DEPLOY_SPN_CLIENT_SECRET = Azure AD client secret            → ARM_CLIENT_SECRET
+#     ARM_TENANT_ID            = Azure AD tenant ID
 #
 # Repository variables (azurerm partial backend — state blob location):
 #   TF_STATE_RESOURCE_GROUP, TF_STATE_STORAGE_ACCOUNT, TF_STATE_CONTAINER, TF_STATE_KEY
@@ -126,15 +136,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Set up Python venv and install dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install pydantic pyyaml croniter
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Validate YAML config with Pydantic
         run: |
-          source .venv/bin/activate
           echo "Validating config: config/lakeflow_dev.yml"
           python tools/pydantic_validator.py "config/lakeflow_dev.yml"
 
@@ -173,21 +184,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Set up Python venv and install dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install databricks-sdk pyyaml
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Terraform Init and Plan
         id: plan
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+          # both credential sets are present to avoid "more than one auth method" error.
+          DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+          # OAuth M2M (Azure or AWS workspaces)
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          # Azure SPN (Entra ID) — Azure workspaces only
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           set -o pipefail
 
@@ -246,18 +266,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.3.1
 
-      - name: Install Python dependencies for local-exec
-        run: |
-          pip3 install --break-system-packages databricks-sdk pyyaml
+      # Uncomment if the self-hosted runner does NOT have the Poetry venv pre-activated.
+      # Works on both self-hosted (pip respects pip.conf proxy) and GitHub-hosted runners.
+      # - name: Install Python dependencies
+      #   run: |
+      #     pip install poetry  # omit if Poetry is already on PATH
+      #     poetry export --without-hashes -f requirements.txt -o requirements.txt
+      #     pip install -r requirements.txt
 
       - name: Terraform Init, Plan, and Apply
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          # Set DATABRICKS_AUTH_TYPE to 'oauth-m2m' or 'azure-client-secret' when
+          # both credential sets are present to avoid "more than one auth method" error.
+          DATABRICKS_AUTH_TYPE: ${{ vars.DATABRICKS_AUTH_TYPE }}
+          # OAuth M2M (Azure or AWS workspaces)
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          # Azure SPN (Entra ID) — Azure workspaces only
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           set -o pipefail
 
@@ -299,11 +330,13 @@ jobs:
       - name: Show deployed resource IDs
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
           ARM_CLIENT_ID: ${{ secrets.DEPLOY_SPN_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.DEPLOY_SPN_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TF_STATE_ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployed Resources" >> $GITHUB_STEP_SUMMARY

--- a/config/examples/cdc_based_connector_database/mysql.yml
+++ b/config/examples/cdc_based_connector_database/mysql.yml
@@ -58,7 +58,7 @@ databases:
 
 gateway_pipeline_cluster_config:
   label: "default"
-  node_type_id: "r5.xlarge"  # Note: This is an AWS compute example being used.
+  node_type_id: "Standard_E4d_v4" # For AWS workspaces, change to a node type applicable to AWS. E.g. 'r5.xlarge'
   autoscale:
     min_workers: 0
     max_workers: 0

--- a/config/examples/cdc_based_connector_database/oracle.yml
+++ b/config/examples/cdc_based_connector_database/oracle.yml
@@ -68,7 +68,7 @@ databases:
 # Create one gateway pipeline for the entire application
 gateway_pipeline_cluster_config:
   label: "default"
-  node_type_id: "Standard_E4d_v4"
+  node_type_id: "Standard_E4d_v4" # For AWS workspaces, change to a node type applicable to AWS. E.g. 'r5.xlarge'
   autoscale:
     min_workers: 0
     max_workers: 0

--- a/config/examples/cdc_based_connector_database/postgresql.yml
+++ b/config/examples/cdc_based_connector_database/postgresql.yml
@@ -80,7 +80,7 @@ databases:
 # Create one gateway pipeline for the entire application
 gateway_pipeline_cluster_config:
   label: "default"
-  node_type_id: "Standard_E4d_v4"
+  node_type_id: "Standard_E4d_v4" # For AWS workspaces, change to a node type applicable to AWS. E.g. 'r5.xlarge'
   autoscale:
     min_workers: 0
     max_workers: 0

--- a/config/examples/cdc_based_connector_database/sqlserver.yml
+++ b/config/examples/cdc_based_connector_database/sqlserver.yml
@@ -46,13 +46,6 @@ databases:
           - source_table: stock_movements
 
   # - name: retail_ops_db_two
-  #   # Optional: Override global_uc_catalog for this specific database
-  #   # uc_catalog: "custom_catalog_name"  # If not provided, uses global_uc_catalog
-  #   
-  #   # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-  #   # schema_prefix: "retail_ops_db_two_"
-  #   # schema_suffix: "_raw"
-  #   
   #   schemas:
   #     - name: dbo
   #       use_schema_ingestion: false
@@ -60,28 +53,7 @@ databases:
   #         - source_table: vendors
   #         - source_table: products
   #         - source_table: product_vendors
-  #    - name: inventory
-  #       use_schema_ingestion: false
-  #       tables:
-  #         - source_table: warehouses
-  #         - source_table: stock_items
-  #         - source_table: stock_movements
-  # - name: retail_ops_db_three
-  #   # Optional: Override global_uc_catalog for this specific database
-  #   # uc_catalog: "custom_catalog_name"  # If not provided, uses global_uc_catalog
-  #   
-  #   # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-  #   # schema_prefix: "retail_ops_db_three_"
-  #   # schema_suffix: "_raw"
-  #   
-  #   schemas:
-  #     - name: dbo
-  #       use_schema_ingestion: false
-  #       tables:
-  #         - source_table: vendors
-  #         - source_table: products
-  #         - source_table: product_vendors
-  #    - name: inventory
+  #     - name: inventory
   #       use_schema_ingestion: false
   #       tables:
   #         - source_table: warehouses
@@ -91,7 +63,7 @@ databases:
 # Create one gateway pipeline for the entire application
 gateway_pipeline_cluster_config:
   label: "default"
-  node_type_id: "Standard_E4d_v4"
+  node_type_id: "Standard_E4d_v4" # For AWS workspaces, change to a node type applicable to AWS. E.g. 'r5.xlarge'
   autoscale:
     min_workers: 0
     max_workers: 0

--- a/config/examples/query_based_connector_database/oracle_qbc.yml
+++ b/config/examples/query_based_connector_database/oracle_qbc.yml
@@ -14,7 +14,7 @@ connector_type: QBC
 
 # UC connection name for the source database (must already exist in Unity Catalog)
 connection:
-  name: "amenon_lf_connect_oracle19c-query-based-connector"
+  name: "lf_connect_oracle19c-query-based-connector"
   source_type: "ORACLE"
   # Note: connection_parameters (source_catalog / CDB name) is NOT needed for QBC —
   # QBC connects via the Unity Catalog connection, not the CDC replication path.
@@ -35,15 +35,17 @@ qbc:
 # In Oracle, the "database" corresponds to the PDB (pluggable database) name.
 databases:
   - name: ORAPDB1
-    uc_catalog: "amenon"   # per-database catalog override
+    uc_catalog: "lf_connect_demo_catalog"   # per-database catalog override
+    schema_prefix: "orapdb1_" # Optionally can add schema_prefix
+    # schema_suffix: "_raw" # Optionally can add schema_suffix
     schemas:
       - name: CLIENT_MANAGEMENT
         use_schema_ingestion: false
         tables:
           - source_table: ACCOUNTS       # inherits default_cursor_column (UPDATED_AT) and default_scd_type
           - source_table: ADVISORS
-          - source_table: CLIENTS
-            scd_type: "SCD_TYPE_2"       # track full client history; cursor stays UPDATED_AT
+          # - source_table: CLIENTS
+          #   scd_type: "SCD_TYPE_2"       # track full client history; cursor stays UPDATED_AT
       # - name: PORTFOLIO_MANAGEMENT
       #   use_schema_ingestion: false
       #   tables:

--- a/config/examples/query_based_connector_database/postgresql_qbc.yml
+++ b/config/examples/query_based_connector_database/postgresql_qbc.yml
@@ -32,6 +32,8 @@ qbc:
 databases:
   - name: wealth_mgmt_one
     uc_catalog: "lf_connect_qbc_wealth_mgmt_one"   # per-database catalog override
+    schema_prefix: "wealth_mgmt_one_" # Optionally can add schema_prefix
+    # schema_suffix: "_raw" # Optionally can add schema_suffix
     schemas:
       - name: client_management
         use_schema_ingestion: false

--- a/config/lakeflow_dev.yml
+++ b/config/lakeflow_dev.yml
@@ -1,71 +1,54 @@
-# Application name and Databricks environment name
+# Refer to docs/yaml-configuration.md for detailed reference on choices that can be made in the configuration file.
+# In-line and block comments are shown in Example YAML files in config/examples directory.
+
 env: "dev"
-app_name: "oracle_test"
+app_name: "retail_ops"
 
-# Provider the name of the Unity catalog connection
 connection:
-  name: "lf_connect_oracle19c"
-  source_type: "ORACLE"
-  # connection_parameters only applies when source_type is ORACLE (e.g. CDB name)
-  connection_parameters:
-    source_catalog: "ORCLCDB"
+  name: "sql_retail_ops_connection"
+  source_type: "SQLSERVER"
 
-# Unity Catalog configuration
-# global_uc_catalog: Default UC catalog where ingestion pipeline tables will land
-# staging_uc_catalog: UC catalog for gateway pipeline staging assets (defaults to global_uc_catalog if not provided)
-# staging_schema: Schema name for gateway pipeline staging assets (defaults to {app_name}_lf_staging if not provided)
 unity_catalog:
   global_uc_catalog: "lf_connect_demo_catalog"
-  staging_uc_catalog: "lf_connect_common_staging"  # Optional: if not provided, defaults to global_uc_catalog
-  staging_schema: "gateway_assets"  # Optional: if not provided, defaults to {app_name}_lf_staging
+  staging_uc_catalog: "lf_connect_common_staging"
+  staging_schema: "gateway_assets"
 
-# The cluster policy used with the deployment of the gateway pipeline
 gateway_pipeline_cluster_policy_name: job_compute_for_spn_for_lf_connect
 
-# List of databases within the Oracle to ingest from
-# The 'use_schema_ingestion' flag determines whether all tables in the schema are ingested automatically (true)
-# or only the explicitly listed tables are ingested (false). Setting it to 'true' will ignore the 'tables' list.
 databases:
-  - name: ORAPDB1
-    # Optional: Override global_uc_catalog for this specific database
-    # uc_catalog: "custom_catalog_name"  # If not provided, uses global_uc_catalog
-
-    # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-    # Example: With prefix "orapdb1_" → orapdb1_client_management
-    # Example: With suffix "_raw" → client_management_raw
-    schema_prefix: "orapdb1_"
-    # schema_suffix: "_raw"
-
+  - name: retail_ops_db_one
+    uc_catalog: "lf_connect_retail_ops"
     schemas:
-      - name: CLIENT_MANAGEMENT
+      - name: dbo
         use_schema_ingestion: false
         tables:
-          # - source_table: CLIENTS
-          - source_table: ACCOUNTS
-          - source_table: ADVISORS
-  # - name: ORAPDB2
-  #   # Optional: Override global_uc_catalog for this specific database
-  #   uc_catalog: "lf_connect_another"  # If not provided, uses global_uc_catalog
-  #
-  #   # Optional: Add prefix/suffix to schema names for this database. In UC, it will be visible as {schema_prefix}{<the schema name>}{schema_suffix}
-  #   schema_prefix: "orapdb2_"
-  #   schema_suffix: "_v2"
-  #
-  #   schemas:
-  #     - name: CLIENT_MANAGEMENT
-  #       use_schema_ingestion: false
-  #       tables:
-  #         - source_table: CLIENTS
-  #         - source_table: ACCOUNTS
-  #         - source_table: ADVISORS
-  #     - name: PORTFOLIO_MANAGEMENT
-  #       use_schema_ingestion: false
-  #       tables:
-  #         - source_table: HOLDINGS
-  #         - source_table: PORTFOLIOS
-  #         - source_table: TRANSACTIONS
+          - source_table: vendors
+          - source_table: products
+          - source_table: product_vendors
+            destination_table: product_vendors_v1
+      - name: inventory
+        use_schema_ingestion: false
+        tables:
+          - source_table: warehouses
+          - source_table: stock_items
+          - source_table: stock_movements
 
-# Create one gateway pipeline for the entire application
+  - name: retail_ops_db_two
+    schemas:
+      - name: dbo
+        use_schema_ingestion: false
+        tables:
+          - source_table: vendors
+          - source_table: products
+          - source_table: product_vendors
+      - name: inventory
+        use_schema_ingestion: false
+        tables:
+          - source_table: warehouses
+          - source_table: stock_items
+          - source_table: stock_movements
+
+
 gateway_pipeline_cluster_config:
   label: "default"
   node_type_id: "Standard_E4d_v4"
@@ -80,39 +63,29 @@ gateway_pipeline_cluster_config:
   spark_env_vars: {}
   ssh_public_keys: []
 
-# Gateway validation configuration : This configuration is used by a script to validate that the gateway pipeline is running before the job resource is created/updated.
-# Set 'enabled: false' to skip validation entirely — useful when pipelines are already running
-# and a validate-only pipeline run would conflict with ongoing ingestion.
 gateway_validation:
   enabled: true
   timeout_minutes: 30
   check_interval_seconds: 15
 
-# Event log configuration : Control whether pipeline event logs are materialized to Delta tables
-# When enabled, event logs are written to Delta tables in the respective schemas:
-#   - Gateway pipeline: logs to the staging schema (<app>_lf_staging)
-#   - Ingestion pipelines: logs to their respective landing schemas (<app>_lf_<database>)
-event_log:
-  to_table: true  # Set to false to disable event log table creation
 
-# Create orchestration using Lakeflow Jobs to run ingestion pipelines
+event_log:
+  to_table: true
+
 job:
   common_job_for_all_pipelines: false
   common_schedule:
-    quartz_cron_expression: "0 */30 * * * ?"  # This schedule applies if 'common_job_for_all_pipelines' is 'true'
+    quartz_cron_expression: "0 */30 * * * ?"
     timezone_id: "UTC"
-
-  # Per-database schedules apply when common_job_for_all_pipelines is false
-  # Each schedule group can apply to one or more databases
-  # Multiple databases can share the same schedule by listing them in 'applies_to'
+  
   per_database_schedules:
     - name: "frequent_sync"
-      applies_to: ["ORAPDB1"]
+      applies_to: [retail_ops_db_two]
       schedule:
-        quartz_cron_expression: "0 */15 * * * ?"  # Run every 15 minutes
+        quartz_cron_expression: "0 */15 * * * ?"
         timezone_id: "UTC"
     - name: "hourly_sync"
-      applies_to: []  # Add "ORAPDB2" when uncommenting second database above
+      applies_to: ["retail_ops_db_one"]
       schedule:
-        quartz_cron_expression: "0 0 * * * ?"  # Run every hour
+        quartz_cron_expression: "0 0 * * * ?"
         timezone_id: "UTC"

--- a/docs/cicd-setup.md
+++ b/docs/cicd-setup.md
@@ -40,14 +40,26 @@ All workflows use `runs-on: self-hosted`. The runner machine must have:
 
 ## Authentication Model
 
-Two separate Azure service principals (SPNs) are used — one for state storage, one for Databricks deployment. No PAT tokens are used anywhere.
+Two identities are used — one for state storage, one for Databricks deployment. No PAT tokens are used anywhere.
 
-| SPN | Secrets | Role |
-|-----|---------|------|
-| **TF State SPN** | `TF_STATE_ARM_CLIENT_ID`, `TF_STATE_ARM_CLIENT_SECRET`, `TF_STATE_ARM_SUBSCRIPTION_ID` | Storage Blob Data Contributor on the Azure Blob container holding Terraform state. Used only during `terraform init`. Never touches Databricks. |
-| **Deploy SPN** | `DEPLOY_SPN_CLIENT_ID`, `DEPLOY_SPN_CLIENT_SECRET` | Service principal registered in Databricks workspace. Used by the Databricks Terraform provider (`ARM_*` env vars) and Databricks SDK during `terraform plan/apply` and refresh workflows. |
+**TF State SPN** (Azure-only, for the `azurerm` Terraform backend):
 
-`ARM_TENANT_ID` is the shared Azure AD tenant — used by both SPNs.
+| Secrets | Role |
+|---------|------|
+| `TF_STATE_ARM_CLIENT_ID`, `TF_STATE_ARM_CLIENT_SECRET`, `TF_STATE_ARM_SUBSCRIPTION_ID` | Storage Blob Data Contributor on the Azure Blob container holding Terraform state. Used only during `terraform init`. Never touches Databricks. |
+
+`ARM_TENANT_ID` is the shared Azure AD tenant used by the TF State SPN.
+
+**Deploy identity** (authenticates to the Databricks workspace):
+
+The workflows support two auth options. The Databricks unified auth layer evaluates them in the order shown — set only the secrets for your target environment:
+
+| Option | Secrets | Workspace support | Priority |
+|--------|---------|-------------------|----------|
+| **A — OAuth M2M** *(recommended)* | `DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET` | Azure **and** AWS | Higher — evaluated first |
+| **B — Azure SPN / Entra ID** | `DEPLOY_SPN_CLIENT_ID`, `DEPLOY_SPN_CLIENT_SECRET`, `ARM_TENANT_ID` | Azure only | Lower — used when Option A secrets are absent |
+
+Both options coexist in the workflow `env:` blocks. If both sets of secrets are populated, OAuth M2M wins. If only the Azure SPN secrets are set, Entra ID auth is used. Set only what applies to your workspace.
 
 See [Installation Guide — Step 4](installation.md#step-4-configure-terraform-backend) for a full explanation of the two-SPN model and backend setup.
 
@@ -55,15 +67,26 @@ See [Installation Guide — Step 4](installation.md#step-4-configure-terraform-b
 
 Configure these under **Settings → Secrets and variables → Actions → Secrets**:
 
+**Always required:**
+
 | Secret | Description | Used by |
 |--------|-------------|---------|
-| `ARM_TENANT_ID` | Azure AD tenant ID — shared by both SPNs | All workflows |
-| `DATABRICKS_HOST` | Databricks workspace URL (e.g. `https://adb-xxx.azuredatabricks.net`) | All workflows |
+| `DATABRICKS_HOST` | Databricks workspace URL (e.g. `https://adb-xxx.azuredatabricks.net` or `https://xxx.azuredatabricks.net`) | All workflows |
 | `TF_STATE_ARM_CLIENT_ID` | Client ID of the **TF State SPN** — authenticates to Azure Blob backend | `terraform-deploy`, `terraform-release`, `terraform-output-pipeline-ids` |
 | `TF_STATE_ARM_CLIENT_SECRET` | Client secret of the TF State SPN | same as above |
 | `TF_STATE_ARM_SUBSCRIPTION_ID` | Azure subscription ID that contains the TF state storage account | same as above |
-| `DEPLOY_SPN_CLIENT_ID` | Client ID of the **Deploy SPN** — used by the Databricks Terraform provider and SDK | All workflows |
-| `DEPLOY_SPN_CLIENT_SECRET` | Client secret of the Deploy SPN | All workflows |
+| `ARM_TENANT_ID` | Azure AD tenant ID — used by the TF State SPN and (if using Option B) the Deploy SPN | All workflows |
+
+**Deploy identity — set Option A or Option B (not both required):**
+
+| Secret | Option | Description | Used by |
+|--------|--------|-------------|---------|
+| `DATABRICKS_CLIENT_ID` | **A — OAuth M2M** | OAuth client ID of the Databricks service principal | All workflows |
+| `DATABRICKS_CLIENT_SECRET` | **A — OAuth M2M** | OAuth client secret of the Databricks service principal | All workflows |
+| `DEPLOY_SPN_CLIENT_ID` | **B — Azure SPN** | Entra ID application (client) ID of the Deploy SPN | All workflows |
+| `DEPLOY_SPN_CLIENT_SECRET` | **B — Azure SPN** | Entra ID client secret of the Deploy SPN | All workflows |
+
+> If both Option A and Option B secrets are configured, the Databricks Terraform provider will error with "more than one authorization method configured". Set `DATABRICKS_AUTH_TYPE` (see Required Repository Variables below) to resolve the conflict explicitly.
 
 ## Required Repository Variables
 
@@ -75,6 +98,62 @@ Configure these under **Settings → Secrets and variables → Actions → Varia
 | `TF_STATE_STORAGE_ACCOUNT` | Azure Storage Account name | same as above |
 | `TF_STATE_CONTAINER` | Blob container name within the storage account | same as above |
 | `TF_STATE_KEY` | Blob path/filename for the `.tfstate` file (e.g. `lakeflow-connect/terraform.tfstate`) | same as above |
+| `DATABRICKS_AUTH_TYPE` | Databricks authentication method. Set to `oauth-m2m` (AWS or Azure OAuth M2M) or `azure-client-secret` (Azure SPN). **Required when both Option A and Option B secrets are configured** to prevent a Terraform provider conflict; leave unset if only one credential set is present. | All workflows |
+
+## Required Databricks Permissions for the Deploy Identity
+
+The service principal used for Terraform plan/apply (Option A OAuth M2M or Option B Azure SPN) must have the following permissions granted in the Databricks workspace **before** running any workflow:
+
+| Permission | Scope | Why |
+|------------|-------|-----|
+| `USE CONNECTION` | Unity Catalog connection to the source database | Required to attach the connection to the gateway pipeline |
+| `USE CATALOG` | Every catalog referenced in the YAML config (`global_uc_catalog`, `staging_uc_catalog`) | Required for Terraform to manage resources within those catalogs |
+| `USE SCHEMA` + `CREATE TABLE` | Every ingestion pipeline target schema | Required to create and manage ingestion pipeline tables |
+| `USE SCHEMA` + `CREATE TABLE` + `CREATE VOLUME` | Staging schema | Required for event log tables and staging volumes |
+| **`CAN USE`** | **Cluster policy named in `gateway_pipeline_cluster_policy_name`** | **Required for the gateway pipeline to spin up compute using that policy. Without this, the gateway pipeline creation fails even if the policy name is correct.** |
+
+### Granting CAN USE on a Cluster Policy
+
+The `gateway_pipeline_cluster_policy_name` field in your YAML config references a cluster policy by name. The deploy service principal must be explicitly granted `CAN USE` on that policy:
+
+1. In the Databricks workspace, go to **Compute → Policies**
+2. Find the policy referenced in your YAML config
+3. Click **Permissions** on the policy
+4. Add the deploy service principal with **Can Use** permission
+
+This applies to both OAuth M2M service principals (Option A) and Azure Entra ID service principals (Option B).
+
+## Required Branch Protection
+
+By default, the `main` branch has no protection rules. Hence, without setting them up, the CI checks are optional and a PR can be merged even if they fail. To make the plan check a required gate before merging, use either approach below.
+
+### Option A — Rulesets (recommended)
+
+Rulesets are GitHub's modern branch protection mechanism. They support dry-run (Evaluation) mode before enforcing, and can be reused across repos at the org level.
+
+1. Go to **Settings → Rules → Rulesets → New ruleset → New branch ruleset**
+2. Set **Ruleset name** to e.g. `Protect main`
+3. Set **Enforcement status** to `Active`
+4. Under **Target branches**, add `main` (or use `Default branch`)
+5. Enable **Require a pull request before merging**
+6. Enable **Require status checks to pass**, then add the following required checks:
+   - `Validate`
+   - `Plan`
+7. Optionally enable **Require branches to be up to date before merging**
+8. Save the ruleset
+
+### Option B — Classic branch protection rules
+
+1. Go to **Settings → Branches → Add branch protection rule**
+2. Set **Branch name pattern** to `main`
+3. Enable **Require status checks to pass before merging**
+4. Search for and add the following required checks:
+   - `Validate`
+   - `Plan`
+5. Optionally enable **Require branches to be up to date before merging**
+6. Save the rule
+
+> **Note:** Status checks only appear in the search list after they have run at least once on a PR. Trigger a test PR first, then come back to add them as required checks.
 
 ## Optional: GitHub Environments for Approval Gates
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,17 +53,34 @@ After validation passes, proceed with Terraform deployment (no Poetry needed for
 
 ## Step 3: Configure Authentication
 
-Set up authentication for the Databricks workspace Terraform provider:
+Set up authentication for the Databricks workspace Terraform provider. The Databricks unified auth layer evaluates methods in priority order and stops at the first match.
 
-**Option A: Personal Login (Development)**
+**Option A: Personal Login (Development — Azure only)**
 ```bash
-# For Azure
 az login
 export DATABRICKS_HOST="https://adb-xxxxx.azuredatabricks.net"
 export DATABRICKS_AUTH_TYPE="azure-cli"
 ```
 
-**Option B: Service Principal**
+**Option B: OAuth M2M — Service Principal (Azure or AWS workspaces)**
+```bash
+export DATABRICKS_HOST="https://<workspace-url>"
+export DATABRICKS_CLIENT_ID="<oauth-client-id>"
+export DATABRICKS_CLIENT_SECRET="<oauth-client-secret>"
+```
+
+Or via a `~/.databrickscfg` profile:
+```ini
+[my-profile]
+host          = https://<workspace-url>
+client_id     = <oauth-client-id>
+client_secret = <oauth-client-secret>
+```
+```bash
+export DATABRICKS_CONFIG_PROFILE=my-profile
+```
+
+**Option C: Azure SPN / Entra ID (Azure workspaces only)**
 ```bash
 # Create profile in ~/.databrickscfg
 cat >> ~/.databrickscfg << EOF
@@ -75,11 +92,10 @@ azure_client_secret = <client_secret>
 auth_type           = azure-client-secret
 EOF
 
-# Set environment variable
 export DATABRICKS_CONFIG_PROFILE=production
 ```
 
-> **CI/CD:** For GitHub Actions deployments, authentication uses a dedicated Deploy SPN with `ARM_*` environment variables rather than `az login` or a config profile. See [GitHub Actions CI/CD Setup](cicd-setup.md) for details.
+> **CI/CD:** GitHub Actions workflows support both OAuth M2M and Azure SPN auth via repository secrets — no `az login` or config profile needed. OAuth M2M is recommended as it works on both Azure and AWS workspaces. See [GitHub Actions CI/CD Setup](cicd-setup.md) for details.
 
 ## Step 4: Configure Terraform Backend
 

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -36,6 +36,7 @@ locals {
         source_catalog      = local.is_mysql ? null : pair.database_name
         source_schema       = local.is_mysql ? pair.database_name : pair.schema_name
         source_table        = table.source_table
+        destination_table   = try(table.destination_table, null)
         destination_catalog = try(table.destination_catalog, pair.uc_catalog)
         destination_schema  = try(table.destination_schema, pair.destination_schema)
         cursor_column       = coalesce(try(table.cursor_column, null), local.qbc_default_cursor_column)

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -121,9 +121,9 @@ module "qbc" {
   source = "./modules/qbc_pipeline"
   count  = local.is_qbc ? 1 : 0
 
-  pipeline_name       = "lf-connect-${local.app_name}-qbc"
-  connection_name     = local.connection.name
-  source_type         = null # serverless — inferred from UC connection
+  pipeline_name   = "lf-connect-${local.app_name}-qbc"
+  connection_name = local.connection.name
+  source_type     = null # serverless — inferred from UC connection
   # Pipeline-level catalog/schema is required by Databricks even when each table
   # specifies its own destination. Fall back to the first table's catalog when
   # global_uc_catalog is null (i.e. per-database uc_catalog overrides are in use).

--- a/infra/modules/qbc_pipeline/main.tf
+++ b/infra/modules/qbc_pipeline/main.tf
@@ -32,6 +32,7 @@ variable "tables" {
     source_table        = string
     destination_catalog = string
     destination_schema  = string
+    destination_table   = optional(string) # Optional: if not provided, uses source_table
     cursor_column       = string
     scd_type            = string
     deletion_condition  = optional(string, null)
@@ -74,7 +75,7 @@ resource "databricks_pipeline" "qbc" {
 
           destination_catalog = objects.value.destination_catalog
           destination_schema  = objects.value.destination_schema
-          # destination_table omitted — defaults to lowercase(source_table)
+          destination_table   = coalesce(objects.value.destination_table, objects.value.source_table)
 
           table_configuration {
             scd_type = objects.value.scd_type

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,17 +1,24 @@
 provider "databricks" {
   # Authentication is configured entirely via environment variables.
+  # The Databricks unified auth layer tries methods in priority order and stops
+  # at the first success. Set only the variables for your target cloud/method.
   #
-  # Local development (azure-cli):
-  #   `DATABRICKS_HOST      = workspace URL` and `DATABRICKS_AUTH_TYPE = azure-cli`
-  #   or 
-  #   `DATABRICKS_CONFIG_PROFILE` if preferred
+  # Local development:
+  #   Azure: az login, then DATABRICKS_HOST + DATABRICKS_AUTH_TYPE=azure-cli
+  #   Any:   DATABRICKS_CONFIG_PROFILE pointing to a profile in ~/.databrickscfg
   #
-  # CI/CD (service principal via Entra ID azure-client-secret):
-  #   DATABRICKS_HOST                = workspace URL
-  #   DATABRICKS_AZURE_CLIENT_ID     = DEPLOY_SPN Entra ID application (client) ID
-  #   DATABRICKS_AZURE_CLIENT_SECRET = DEPLOY_SPN Entra ID client secret
-  #   DATABRICKS_AZURE_TENANT_ID     = Azure AD tenant ID
+  # CI/CD — Option A: OAuth M2M (Azure or AWS workspaces, recommended):
+  #   DATABRICKS_HOST          = workspace URL
+  #   DATABRICKS_CLIENT_ID     = Databricks service principal OAuth client ID
+  #   DATABRICKS_CLIENT_SECRET = Databricks service principal OAuth client secret
   #
-  # In CI/CD, these env vars are set in the shell after unsetting ARM_*
-  # (which are used by the azurerm backend for terraform state).
+  # CI/CD — Option B: Azure SPN / Entra ID (Azure workspaces only):
+  #   DATABRICKS_HOST  = workspace URL
+  #   ARM_CLIENT_ID    = DEPLOY_SPN Entra ID application (client) ID
+  #   ARM_CLIENT_SECRET = DEPLOY_SPN Entra ID client secret
+  #   ARM_TENANT_ID    = Azure AD tenant ID
+  #
+  # Note: ARM_* vars are also used by the azurerm backend for Terraform state.
+  # The backend uses TF_STATE_ARM_* secrets (separate SPN); the Databricks
+  # provider uses DEPLOY_SPN ARM_* secrets for plan/apply.
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,11 @@ files = [
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "certifi"
 version = "2026.1.4"
@@ -23,6 +28,11 @@ files = [
     {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
     {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "cffi"
@@ -121,6 +131,11 @@ files = [
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "charset-normalizer"
@@ -245,12 +260,17 @@ files = [
     {file = "charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"},
 ]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "croniter"
 version = "2.0.7"
 description = "croniter provides iteration for datetime object with cron like format"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.6"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 groups = ["main"]
 files = [
     {file = "croniter-2.0.7-py2.py3-none-any.whl", hash = "sha256:f15e80828d23920c4bb7f4d9340b932c9dcabecafc7775703c8b36d1253ed526"},
@@ -261,12 +281,17 @@ files = [
 python-dateutil = "*"
 pytz = ">2021.1"
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "cryptography"
 version = "46.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+python-versions = ">=3.8, !=3.9.0, !=3.9.1"
 groups = ["main"]
 files = [
     {file = "cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485"},
@@ -334,26 +359,37 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi (>=2024)", "cryptography-vectors (==46.0.4)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "databricks-sdk"
-version = "0.64.0"
+version = "0.102.0"
 description = "Databricks SDK for Python (Beta)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "databricks_sdk-0.64.0-py3-none-any.whl", hash = "sha256:3efb2a739deda3186d0380ad6ced7d4811ced7adcaf61cbf0f897eab52974a17"},
-    {file = "databricks_sdk-0.64.0.tar.gz", hash = "sha256:e21cce45bb4f1254ad5d22ea77fc30484378beb54b5b42db098d1f975c813e81"},
+    {file = "databricks_sdk-0.102.0-py3-none-any.whl", hash = "sha256:75d1253276ee8f3dd5e7b00d62594b7051838435e618f74a8570a6dbd723ec12"},
+    {file = "databricks_sdk-0.102.0.tar.gz", hash = "sha256:8fa5f82317ee27cc46323c6e2543d2cfefb4468653f92ba558271043c6f72fb9"},
 ]
 
 [package.dependencies]
 google-auth = ">=2.0,<3.0"
+protobuf = ">=4.25.8,<5.26.dev0 || >5.29.0,<5.29.1 || >5.29.1,<5.29.2 || >5.29.2,<5.29.3 || >5.29.3,<5.29.4 || >5.29.4,<6.30.0 || >6.30.0,<6.30.1 || >6.30.1,<6.31.0 || >6.31.0,<7.0"
 requests = ">=2.28.1,<3"
 
 [package.extras]
-dev = ["autoflake", "black", "build", "databricks-connect", "httpx", "ipython", "ipywidgets", "isort", "langchain-openai ; python_version > \"3.7\"", "openai", "pycodestyle", "pyfakefs", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-xdist", "requests-mock", "wheel"]
+dev = ["autoflake (==2.3.1)", "black (==24.8.0)", "build", "databricks-connect", "httpx", "ipython", "ipywidgets", "isort (==5.13.2)", "langchain-openai ; python_version > \"3.7\"", "openai", "pycodestyle", "pyfakefs", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-xdist (>=3.6.1,<4.0)", "requests-mock", "wheel"]
 notebook = ["ipython (>=8,<10)", "ipywidgets (>=8,<9)"]
 openai = ["httpx", "langchain-openai ; python_version > \"3.7\"", "openai"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "google-auth"
@@ -383,6 +419,11 @@ requests = ["requests (>=2.20.0,<3.0.0)"]
 testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "flask", "freezegun", "grpcio", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
 urllib3 = ["packaging", "urllib3"]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "idna"
 version = "3.11"
@@ -398,6 +439,36 @@ files = [
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+description = ""
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3"},
+    {file = "protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326"},
+    {file = "protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593"},
+    {file = "protobuf-6.33.6-cp39-cp39-win32.whl", hash = "sha256:bd56799fb262994b2c2faa1799693c95cc2e22c62f56fb43af311cae45d26f0e"},
+    {file = "protobuf-6.33.6-cp39-cp39-win_amd64.whl", hash = "sha256:f443a394af5ed23672bc6c486be138628fbe5c651ccbc536873d7da23d1868cf"},
+    {file = "protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901"},
+    {file = "protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "pyasn1"
 version = "0.6.2"
@@ -409,6 +480,11 @@ files = [
     {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
     {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "pyasn1-modules"
@@ -425,6 +501,11 @@ files = [
 [package.dependencies]
 pyasn1 = ">=0.6.1,<0.7.0"
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "pycparser"
 version = "3.0"
@@ -437,6 +518,11 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "pydantic"
@@ -459,6 +545,11 @@ typing-inspection = ">=0.4.2"
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
 timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "pydantic-core"
@@ -594,6 +685,11 @@ files = [
 [package.dependencies]
 typing-extensions = ">=4.14.1"
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
@@ -609,6 +705,11 @@ files = [
 [package.dependencies]
 six = ">=1.5"
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "pytz"
 version = "2025.2"
@@ -620,6 +721,11 @@ files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "pyyaml"
@@ -704,6 +810,11 @@ files = [
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "requests"
 version = "2.32.5"
@@ -726,12 +837,17 @@ urllib3 = ">=1.21.1,<3"
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "rsa"
 version = "4.9.1"
 description = "Pure-Python RSA implementation"
 optional = false
-python-versions = "<4,>=3.6"
+python-versions = ">=3.6,<4"
 groups = ["main"]
 files = [
     {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
@@ -740,6 +856,11 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "ruff"
@@ -769,17 +890,27 @@ files = [
     {file = "ruff-0.5.7.tar.gz", hash = "sha256:8dfc0a458797f5d9fb622dd0efc52d796f23f0a1493a9527f4e49a550ae9a7e5"},
 ]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 groups = ["main"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "typing-extensions"
@@ -792,6 +923,11 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "typing-inspection"
@@ -807,6 +943,11 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
+
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
 
 [[package]]
 name = "urllib3"
@@ -826,7 +967,12 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
+[package.source]
+type = "legacy"
+url = "https://pypi-proxy.dev.databricks.com/simple"
+reference = "databricks-proxy"
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "624ecf9766c8d152d95c66c60cd29b9683f02c02c0007fa889530f69f5c5f8b8"
+content-hash = "0eca5b1917fdd3d11be373522be70f41fc9051dad9520edfff97bff5eae70803"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 pyyaml = "^6.0.2"
-databricks-sdk = "^0.64.0"
+databricks-sdk = "^0.102.0"
 pydantic = "^2.0.0"
 croniter = "^2.0.0"
 


### PR DESCRIPTION
## Authentication — OAuth M2M + Azure SPN dual support

  All GitHub Actions workflows (terraform-deploy, terraform-release,
  full-refresh-pipeline, full-refresh-tables, terraform-output-pipeline-ids)
  now expose two auth credential sets in every `env:` block:

    Option A — OAuth M2M (Azure or AWS workspaces):
      DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET

    Option B — Azure SPN / Entra ID (Azure workspaces only):
      DEPLOY_SPN_CLIENT_ID / DEPLOY_SPN_CLIENT_SECRET / ARM_TENANT_ID

  DATABRICKS_AUTH_TYPE is threaded through as a repository variable to
  disambiguate when both sets are present (prevents "more than one auth
  method" Terraform provider error). provider.tf updated to document both
  options and their precedence under the Databricks unified auth layer.

  ## Detect Changes CI job

  terraform-deploy.yml PR trigger no longer uses `paths:` filtering.
  Instead, a new `changes` job runs on every PR and outputs `infra=true/false`
  based on whether infra/, config/, or tools/ files were touched.
  Validate and Plan jobs depend on this output and skip when no infra
  changes are detected. A companion `plan-skip` job runs under the same
  name ("Plan") when infra is unchanged, satisfying the required status
  check without running Terraform — enabling docs-only PRs to merge cleanly.

  ## Python dependency management on self-hosted runners

  Removed all inline `pip install` / `python -m venv` steps from every
  workflow. These relied on --break-system-packages or transient venvs
  that conflicted with managed runner environments. Replaced with a
  commented-out Poetry-based snippet (poetry export → pip install) that
  users can uncomment on runners without a pre-activated venv. Assumes
  Poetry venv is active on standard self-hosted runners.

  databricks-sdk bumped from ^0.64.0 to ^0.102.0 in pyproject.toml;
  poetry.lock regenerated.

  ## QBC pipeline: destination_table override

  infra/locals.tf: table object now includes destination_table =
  try(table.destination_table, null).
  infra/modules/qbc_pipeline/main.tf: destination_table is now an
  optional variable field; the pipeline resource sets it explicitly to
  coalesce(destination_table, source_table) rather than omitting it.
  This allows a YAML config to rename a table in Unity Catalog without
  renaming it at the source (e.g. product_vendors → product_vendors_v1).

  ## Example configs restructured

  Flat config/examples/*.yml files reorganised into two subdirectories:
    config/examples/cdc_based_connector_database/ — mysql, oracle, postgresql, sqlserver
    config/examples/query_based_connector_database/ — oracle_qbc, postgresql_qbc

  ## config/ refreshed

  Updated from an Oracle CDC stub to a SQL Server CDC example (two
  databases, two schemas each, per-database schedules, uc_catalog
  override, destination_table rename) to showcase more of the available
  YAML surface area. Verbose inline comments removed — reference
  docs/yaml-configuration.md instead.

  ## Docs updated

  docs/cicd-setup.md: Auth section rewritten to cover both options with
  a comparison table, required Databricks permissions section added
  (USE CONNECTION, USE CATALOG, USE SCHEMA, CAN USE on cluster policy),
  and a new Required Branch Protection section documenting both Rulesets
  and classic rules.
  docs/installation.md: Step 3 expanded to document all three auth
  paths (az login, OAuth M2M, Azure SPN/Entra ID).