### PR TITLE
feat: add permissions support for deployed pipelines and jobs

### DIFF
--- a/config/examples/cdc_based_connector_database/mysql.yml
+++ b/config/examples/cdc_based_connector_database/mysql.yml
@@ -80,6 +80,18 @@ gateway_validation:
 event_log:
   to_table: true
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 job:
   common_job_for_all_pipelines: false
   common_schedule:

--- a/config/examples/cdc_based_connector_database/oracle.yml
+++ b/config/examples/cdc_based_connector_database/oracle.yml
@@ -95,6 +95,18 @@ gateway_validation:
 event_log:
   to_table: true  # Set to false to disable event log table creation
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Create orchestration using Lakeflow Jobs to run ingestion pipelines
 job:
   common_job_for_all_pipelines: false

--- a/config/examples/cdc_based_connector_database/postgresql.yml
+++ b/config/examples/cdc_based_connector_database/postgresql.yml
@@ -107,6 +107,18 @@ gateway_validation:
 event_log:
   to_table: true  # Set to false to disable event log table creation
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Create orchestration using Lakeflow Jobs to run ingestion pipelines
 job:
   common_job_for_all_pipelines: false

--- a/config/examples/cdc_based_connector_database/sqlserver.yml
+++ b/config/examples/cdc_based_connector_database/sqlserver.yml
@@ -90,6 +90,18 @@ gateway_validation:
 event_log:
   to_table: true  # Set to false to disable event log table creation
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Create orchestration using Lakeflow Jobs to run ingestion pipelines
 job:
   common_job_for_all_pipelines: false

--- a/config/examples/query_based_connector_foreign_catalog/snowflake_qbc.yml
+++ b/config/examples/query_based_connector_foreign_catalog/snowflake_qbc.yml
@@ -71,6 +71,18 @@ databases:
 event_log:
   to_table: true
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Job orchestration — QBC_FOREIGN_CATALOG always uses the common schedule
 job:
   common_job_for_all_pipelines: true

--- a/config/examples/query_based_connector_foreign_connection/oracle_qbc.yml
+++ b/config/examples/query_based_connector_foreign_connection/oracle_qbc.yml
@@ -75,6 +75,18 @@ databases:
 event_log:
   to_table: true
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Job orchestration — QBC always uses the common schedule
 job:
   common_job_for_all_pipelines: true

--- a/config/examples/query_based_connector_foreign_connection/postgresql_qbc.yml
+++ b/config/examples/query_based_connector_foreign_connection/postgresql_qbc.yml
@@ -73,6 +73,18 @@ databases:
 event_log:
   to_table: true
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Job orchestration — QBC always uses the common schedule
 job:
   common_job_for_all_pipelines: true

--- a/config/examples/query_based_connector_foreign_connection/sqlserver_qbc.yml
+++ b/config/examples/query_based_connector_foreign_connection/sqlserver_qbc.yml
@@ -74,6 +74,18 @@ databases:
 event_log:
   to_table: true
 
+# Optional: Uncomment and document `permissions` block to grant access to all deployed pipelines and jobs.
+# Supported levels: CAN_VIEW, CAN_RUN, CAN_MANAGE
+# Supported principal types: user_name, group_name, service_principal_name
+# Note: CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources.
+# permissions:
+#   - level: CAN_MANAGE
+#     service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
+#   - level: CAN_RUN
+#     group_name: data-engineers
+#   - level: CAN_VIEW
+#     user_name: user@example.com
+
 # Job orchestration — QBC always uses the common schedule
 job:
   common_job_for_all_pipelines: true

--- a/config/lakeflow_dev.yml
+++ b/config/lakeflow_dev.yml
@@ -64,13 +64,23 @@ gateway_pipeline_cluster_config:
   ssh_public_keys: []
 
 gateway_validation:
-  enabled: true
+  enabled: false
   timeout_minutes: 30
   check_interval_seconds: 15
 
 
 event_log:
   to_table: true
+
+permissions:
+  - level: CAN_RUN
+    group_name: pipeline_runner_grp
+  - level: CAN_VIEW
+    user_name: user@example.com
+  - level: CAN_MANAGE
+    group_name: dbx_pipeline_admin_grp
+  - level: CAN_RUN
+    service_principal_name: a4d1e001-d123-4b99-9876-12345e8df1d1
 
 job:
   common_job_for_all_pipelines: false

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -140,6 +140,38 @@ When `to_table: true`, pipeline event logs are materialized to Delta tables:
 - Gateway pipeline logs → staging schema (e.g. `{app_name}_lf_staging`)
 - Ingestion pipeline logs → their respective landing schemas
 
+## Permissions
+
+```yaml
+# Optional
+permissions:
+  - level: CAN_MANAGE
+    service_principal_name: a4d1e08b-d613-4b77-8750-53834e8df0d0
+  - level: CAN_VIEW
+    user_name: user@databricks.com
+  - level: CAN_VIEW
+    group_name: data-engineers
+```
+
+When specified, permissions are applied to **all deployed Databricks resources** — gateway and ingestion pipelines (CDC), QBC pipeline (QBC / QBC_FOREIGN_CATALOG), and all orchestration jobs.
+
+Supported permission levels:
+
+| Level | Pipelines | Jobs |
+|-------|-----------|------|
+| `CAN_VIEW` | ✓ | ✓ |
+| `CAN_RUN` | ✓ | ✓ (auto-mapped to `CAN_MANAGE_RUN`) |
+| `CAN_MANAGE` | ✓ | ✓ |
+
+Each entry must specify exactly one of:
+- `user_name`: Databricks user email address
+- `group_name`: Databricks group name
+- `service_principal_name`: Service principal application ID (UUID)
+
+> **Note:** Databricks jobs have no `CAN_RUN` permission level; the equivalent is `CAN_MANAGE_RUN`. If you specify `CAN_RUN` in the `permissions` block it is silently mapped to `CAN_MANAGE_RUN` when applied to job resources, so the same block works uniformly across all resource types.
+
+If `permissions` is omitted entirely, no `databricks_permissions` resources are created and Databricks workspace defaults apply.
+
 ## Job Orchestration
 
 ```yaml

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -180,4 +180,14 @@ locals {
       pair.pair_key if contains(schedule_config.applies_to, pair.database_name)
     ]
   }
+
+  # Permissions are optional; omit from YAML to skip databricks_permissions resource creation. Applied uniformly to all deployed pipelines and jobs.
+  permissions = try(local.cfg.permissions, [])
+
+  # Job permissions: identical to pipeline permissions except CAN_RUN → CAN_MANAGE_RUN (Databricks jobs have no CAN_RUN level; CAN_MANAGE_RUN is the equivalent )
+  job_permissions = [
+    for p in try(local.cfg.permissions, []) : merge(p, {
+      level = p.level == "CAN_RUN" ? "CAN_MANAGE_RUN" : p.level
+    })
+  ]
 } 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -40,6 +40,7 @@ module "gateway" {
   cluster                 = local.cfg.gateway_pipeline_cluster_config
   cluster_policy_name     = local.cfg.gateway_pipeline_cluster_policy_name
   event_log_to_table      = local.event_log_to_table
+  permissions             = local.permissions
   depends_on              = [module.staging]
 }
 
@@ -59,6 +60,7 @@ module "ingestion" {
   specific_tables       = each.value.specific_tables
   source_configurations = lookup(local.database_source_configurations, each.value.database_name, null)
   event_log_to_table    = local.event_log_to_table
+  permissions           = local.permissions
 
   depends_on = [module.gateway, module.landing_catalog_validation]
 }
@@ -88,6 +90,7 @@ module "orchestrator_shared_all_pipelines" {
   ingestion_pipelines = { for k, v in module.ingestion : k => v.pipeline_id }
   schedule            = local.job.common_schedule
   is_common_job       = true
+  permissions         = local.job_permissions
 
   depends_on = [module.gateway_validation]
 }
@@ -108,6 +111,7 @@ module "orchestrator_per_schedule" {
     "schedule"
   )
   is_common_job = false
+  permissions   = local.job_permissions
 
   depends_on = [module.gateway_validation]
 }
@@ -131,6 +135,7 @@ module "qbc" {
   destination_schema  = local.qbc_tables[0].destination_schema
   tables              = local.qbc_tables
   event_log_to_table  = local.event_log_to_table
+  permissions         = local.permissions
 
   depends_on = [module.landing_catalog_validation]
 }
@@ -144,6 +149,7 @@ module "orchestrator_qbc" {
   ingestion_pipelines = { "qbc" = module.qbc[0].pipeline_id }
   schedule            = local.job.common_schedule
   is_common_job       = true
+  permissions         = local.job_permissions
 
   depends_on = [module.qbc]
 }
@@ -166,6 +172,7 @@ module "qbc_fc" {
   tables                         = local.qbc_fc_tables
   pipeline_configuration         = local.qbc_fc_pipeline_configuration
   event_log_to_table             = local.event_log_to_table
+  permissions                    = local.permissions
 
   depends_on = [module.landing_catalog_validation]
 }
@@ -178,6 +185,7 @@ module "orchestrator_qbc_fc" {
   ingestion_pipelines = { "qbc" = module.qbc_fc[0].pipeline_id }
   schedule            = local.job.common_schedule
   is_common_job       = true
+  permissions         = local.job_permissions
 
   depends_on = [module.qbc_fc]
 }

--- a/infra/modules/gateway_pipeline/main.tf
+++ b/infra/modules/gateway_pipeline/main.tf
@@ -67,6 +67,17 @@ variable "event_log_to_table" {
   default     = true
 }
 
+variable "permissions" {
+  description = "List of permission grants for this pipeline"
+  type = list(object({
+    level                  = string
+    user_name              = optional(string)
+    group_name             = optional(string)
+    service_principal_name = optional(string)
+  }))
+  default = []
+}
+
 # Gather the existing cluster policy using name
 data "databricks_cluster_policy" "app_cluster_policy" {
   name = var.cluster_policy_name
@@ -129,6 +140,21 @@ resource "databricks_pipeline" "gateway" {
 
 }
 
+resource "databricks_permissions" "pipeline_perms" {
+  count       = length(var.permissions) > 0 ? 1 : 0
+  pipeline_id = databricks_pipeline.gateway.id
+
+  dynamic "access_control" {
+    for_each = var.permissions
+    content {
+      user_name              = try(access_control.value.user_name, null)
+      group_name             = try(access_control.value.group_name, null)
+      service_principal_name = try(access_control.value.service_principal_name, null)
+      permission_level       = access_control.value.level
+    }
+  }
+}
+
 output "pipeline_id" {
   value = databricks_pipeline.gateway.id
-} 
+}

--- a/infra/modules/ingestion_pipeline/main.tf
+++ b/infra/modules/ingestion_pipeline/main.tf
@@ -66,6 +66,17 @@ variable "event_log_to_table" {
   default     = true
 }
 
+variable "permissions" {
+  description = "List of permission grants for this pipeline"
+  type = list(object({
+    level                  = string
+    user_name              = optional(string)
+    group_name             = optional(string)
+    service_principal_name = optional(string)
+  }))
+  default = []
+}
+
 resource "databricks_pipeline" "ingest" {
   name = var.name
   ingestion_definition {
@@ -131,6 +142,21 @@ resource "databricks_pipeline" "ingest" {
 }
 
 
+resource "databricks_permissions" "pipeline_perms" {
+  count       = length(var.permissions) > 0 ? 1 : 0
+  pipeline_id = databricks_pipeline.ingest.id
+
+  dynamic "access_control" {
+    for_each = var.permissions
+    content {
+      user_name              = try(access_control.value.user_name, null)
+      group_name             = try(access_control.value.group_name, null)
+      service_principal_name = try(access_control.value.service_principal_name, null)
+      permission_level       = access_control.value.level
+    }
+  }
+}
+
 output "pipeline_id" {
   value = databricks_pipeline.ingest.id
-} 
+}

--- a/infra/modules/job/main.tf
+++ b/infra/modules/job/main.tf
@@ -20,6 +20,17 @@ variable "is_common_job" {
   type        = bool
 }
 
+variable "permissions" {
+  description = "List of permission grants for this job"
+  type = list(object({
+    level                  = string
+    user_name              = optional(string)
+    group_name             = optional(string)
+    service_principal_name = optional(string)
+  }))
+  default = []
+}
+
 # Create one job with all pipelines in it (for common job scenario)
 resource "databricks_job" "common_orchestrator_all_pipelines" {
   count = var.is_common_job ? 1 : 0
@@ -66,6 +77,36 @@ resource "databricks_job" "individual_orchestrator" {
   schedule {
     quartz_cron_expression = var.schedule.quartz_cron_expression
     timezone_id            = var.schedule.timezone_id
+  }
+}
+
+resource "databricks_permissions" "common_job_perms" {
+  count  = (var.is_common_job && length(var.permissions) > 0) ? 1 : 0
+  job_id = databricks_job.common_orchestrator_all_pipelines[0].id
+
+  dynamic "access_control" {
+    for_each = var.permissions
+    content {
+      user_name              = try(access_control.value.user_name, null)
+      group_name             = try(access_control.value.group_name, null)
+      service_principal_name = try(access_control.value.service_principal_name, null)
+      permission_level       = access_control.value.level
+    }
+  }
+}
+
+resource "databricks_permissions" "individual_job_perms" {
+  count  = (!var.is_common_job && length(var.permissions) > 0) ? 1 : 0
+  job_id = databricks_job.individual_orchestrator[0].id
+
+  dynamic "access_control" {
+    for_each = var.permissions
+    content {
+      user_name              = try(access_control.value.user_name, null)
+      group_name             = try(access_control.value.group_name, null)
+      service_principal_name = try(access_control.value.service_principal_name, null)
+      permission_level       = access_control.value.level
+    }
   }
 }
 

--- a/infra/modules/qbc_pipeline/main.tf
+++ b/infra/modules/qbc_pipeline/main.tf
@@ -59,6 +59,17 @@ variable "event_log_to_table" {
   default     = true
 }
 
+variable "permissions" {
+  description = "List of permission grants for this pipeline"
+  type = list(object({
+    level                  = string
+    user_name              = optional(string)
+    group_name             = optional(string)
+    service_principal_name = optional(string)
+  }))
+  default = []
+}
+
 resource "databricks_pipeline" "qbc" {
   name = var.pipeline_name
 
@@ -107,6 +118,21 @@ resource "databricks_pipeline" "qbc" {
           }
         }
       }
+    }
+  }
+}
+
+resource "databricks_permissions" "pipeline_perms" {
+  count       = length(var.permissions) > 0 ? 1 : 0
+  pipeline_id = databricks_pipeline.qbc.id
+
+  dynamic "access_control" {
+    for_each = var.permissions
+    content {
+      user_name              = try(access_control.value.user_name, null)
+      group_name             = try(access_control.value.group_name, null)
+      service_principal_name = try(access_control.value.service_principal_name, null)
+      permission_level       = access_control.value.level
     }
   }
 }


### PR DESCRIPTION
Introduces an optional `permissions` block in the YAML config that grants Databricks access (CAN_VIEW, CAN_RUN, CAN_MANAGE) to all deployed pipelines and jobs via databricks_permissions resources. Applies uniformly across CDC, QBC, and QBC_FOREIGN_CATALOG connector types. CAN_RUN is automatically mapped to CAN_MANAGE_RUN for job resources. Omitting the block leaves Databricks workspace defaults in place.