### PR TITLE
feat: add gateway_pipeline_configuration support for CDC gateway pipeline

### DIFF
--- a/config/examples/cdc_based_connector_database/mysql.yml
+++ b/config/examples/cdc_based_connector_database/mysql.yml
@@ -77,6 +77,13 @@ gateway_validation:
   timeout_minutes: 30
   check_interval_seconds: 15
 
+# Optional: Spark configuration applied to the gateway pipeline only.
+# Does not apply to managed ingestion pipelines.
+# Note: spark.databricks.acl.needAdminPermissionToViewLogs requires CAN_VIEW or higher
+# on the pipeline — ensure the permissions block is configured accordingly.
+# gateway_pipeline_configuration:
+#   spark.databricks.acl.needAdminPermissionToViewLogs: "false"
+
 event_log:
   to_table: true
 

--- a/config/examples/cdc_based_connector_database/oracle.yml
+++ b/config/examples/cdc_based_connector_database/oracle.yml
@@ -88,6 +88,13 @@ gateway_validation:
   timeout_minutes: 30
   check_interval_seconds: 15
 
+# Optional: Spark configuration applied to the gateway pipeline only.
+# Does not apply to managed ingestion pipelines.
+# Note: spark.databricks.acl.needAdminPermissionToViewLogs requires CAN_VIEW or higher
+# on the pipeline — ensure the permissions block is configured accordingly.
+# gateway_pipeline_configuration:
+#   spark.databricks.acl.needAdminPermissionToViewLogs: "false"
+
 # Event log configuration : Control whether pipeline event logs are materialized to Delta tables
 # When enabled, event logs are written to Delta tables in the respective schemas:
 #   - Gateway pipeline: logs to the staging schema (<app>_lf_staging)

--- a/config/examples/cdc_based_connector_database/postgresql.yml
+++ b/config/examples/cdc_based_connector_database/postgresql.yml
@@ -100,6 +100,13 @@ gateway_validation:
   timeout_minutes: 30
   check_interval_seconds: 15
 
+# Optional: Spark configuration applied to the gateway pipeline only.
+# Does not apply to managed ingestion pipelines.
+# Note: spark.databricks.acl.needAdminPermissionToViewLogs requires CAN_VIEW or higher
+# on the pipeline — ensure the permissions block is configured accordingly.
+# gateway_pipeline_configuration:
+#   spark.databricks.acl.needAdminPermissionToViewLogs: "false"
+
 # Event log configuration : Control whether pipeline event logs are materialized to Delta tables
 # When enabled, event logs are written to Delta tables in the respective schemas:
 #   - Gateway pipeline: logs to the staging schema (<app>_lf_staging)

--- a/config/examples/cdc_based_connector_database/sqlserver.yml
+++ b/config/examples/cdc_based_connector_database/sqlserver.yml
@@ -83,6 +83,13 @@ gateway_validation:
   timeout_minutes: 30
   check_interval_seconds: 15
 
+# Optional: Spark configuration applied to the gateway pipeline only.
+# Does not apply to managed ingestion pipelines.
+# Note: spark.databricks.acl.needAdminPermissionToViewLogs requires CAN_VIEW or higher
+# on the pipeline — ensure the permissions block is configured accordingly.
+# gateway_pipeline_configuration:
+#   spark.databricks.acl.needAdminPermissionToViewLogs: "false"
+
 # Event log configuration : Control whether pipeline event logs are materialized to Delta tables
 # When enabled, event logs are written to Delta tables in the respective schemas:
 #   - Gateway pipeline: logs to the staging schema (<app>_lf_staging)

--- a/config/lakeflow_dev.yml
+++ b/config/lakeflow_dev.yml
@@ -68,6 +68,8 @@ gateway_validation:
   timeout_minutes: 30
   check_interval_seconds: 15
 
+gateway_pipeline_configuration:
+  spark.databricks.acl.needAdminPermissionToViewLogs: "false"
 
 event_log:
   to_table: true

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -243,3 +243,17 @@ After the gateway pipeline is created or updated, a validation script polls the 
 
 - `timeout_minutes`: How long to wait for the gateway to reach a running state before failing (minimum 15).
 - `check_interval_seconds`: How frequently to poll the pipeline status (minimum 5).
+
+## Gateway Pipeline Configuration
+
+```yaml
+# Optional
+gateway_pipeline_configuration:
+  spark.databricks.acl.needAdminPermissionToViewLogs: "false"
+```
+
+Optional Spark configuration key-value pairs applied to the **gateway pipeline only**. Not passed to managed ingestion pipelines.
+
+The primary use case is `spark.databricks.acl.needAdminPermissionToViewLogs: "false"`, which allows non-workspace admin users who have `CAN_VIEW` or higher on the pipeline to view its cluster logs. This setting requires at least `CAN_VIEW` to be granted on the pipeline via the [`permissions`](#permissions) block. Without that, non-workspace admin users cannot access the pipeline at all regardless of the log setting.
+
+Any valid Databricks pipeline Spark configuration key can be provided. The block is omitted from the Terraform resource entirely when not specified.

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -181,6 +181,9 @@ locals {
     ]
   }
 
+  # Optional Spark configuration for the gateway pipeline only (i.e not passed to managed ingestion pipelines)
+  gateway_pipeline_configuration = try(local.cfg.gateway_pipeline_configuration, {})
+
   # Permissions are optional; omit from YAML to skip databricks_permissions resource creation. Applied uniformly to all deployed pipelines and jobs.
   permissions = try(local.cfg.permissions, [])
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -40,6 +40,7 @@ module "gateway" {
   cluster                 = local.cfg.gateway_pipeline_cluster_config
   cluster_policy_name     = local.cfg.gateway_pipeline_cluster_policy_name
   event_log_to_table      = local.event_log_to_table
+  pipeline_configuration  = local.gateway_pipeline_configuration
   permissions             = local.permissions
   depends_on              = [module.staging]
 }

--- a/infra/modules/gateway_pipeline/main.tf
+++ b/infra/modules/gateway_pipeline/main.tf
@@ -67,6 +67,12 @@ variable "event_log_to_table" {
   default     = true
 }
 
+variable "pipeline_configuration" {
+  description = "Optional Spark configuration key-value pairs applied to the gateway pipeline only. Not passed to ingestion pipelines."
+  type        = map(string)
+  default     = {}
+}
+
 variable "permissions" {
   description = "List of permission grants for this pipeline"
   type = list(object({
@@ -102,6 +108,7 @@ resource "databricks_pipeline" "gateway" {
       }
     }
   }
+  configuration          = length(var.pipeline_configuration) > 0 ? var.pipeline_configuration : null
   allow_duplicate_names  = false
   development            = false
   continuous             = true


### PR DESCRIPTION
Introduces an optional gateway_pipeline_configuration block in the YAML config that passes Spark key-value pairs to the gateway pipeline only. Ingestion pipelines are unaffected. Primary use case is `spark.databricks.acl.needAdminPermissionToViewLogs: "false"`, which allows non-admin users with CAN_VIEW or higher to view cluster logs — requires the permissions block to be set accordingly.